### PR TITLE
[FEAT] #4 - 비밀번호 재발급 기능 구현

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,12 @@
 			<version>0.11.5</version>
 			<scope>runtime</scope>
 		</dependency>
+
+		<!-- Google SMTP -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-mail</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/ssafy/questory/controller/MemberController.java
+++ b/src/main/java/com/ssafy/questory/controller/MemberController.java
@@ -1,9 +1,11 @@
 package com.ssafy.questory.controller;
 
+import com.ssafy.questory.dto.request.member.MemberFindPasswordRequestDto;
 import com.ssafy.questory.dto.request.member.MemberLoginRequestDto;
 import com.ssafy.questory.dto.request.member.MemberRegistRequestDto;
 import com.ssafy.questory.dto.response.member.MemberRegistResponseDto;
 import com.ssafy.questory.dto.response.member.MemberTokenResponseDto;
+import com.ssafy.questory.service.MailSendService;
 import com.ssafy.questory.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -13,11 +15,14 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.Map;
+
 @RestController()
 @RequestMapping("/members")
 @RequiredArgsConstructor
 public class MemberController {
     private final MemberService userService;
+    private final MailSendService mailSendService;
 
     @PostMapping("/regist")
     public ResponseEntity<MemberRegistResponseDto> regist(@RequestBody MemberRegistRequestDto memberRegistRequestDto) {
@@ -29,5 +34,14 @@ public class MemberController {
     public ResponseEntity<MemberTokenResponseDto> login(@RequestBody MemberLoginRequestDto memberLoginRequestDto) {
         MemberTokenResponseDto memberTokenResponseDto = userService.login(memberLoginRequestDto);
         return ResponseEntity.status(HttpStatus.OK).body(memberTokenResponseDto);
+    }
+
+    @PostMapping("/find-password")
+    public ResponseEntity<Map<String, String>> findPassword(
+            @RequestBody MemberFindPasswordRequestDto memberFindPasswordRequestDto) {
+        mailSendService.createAndSendEmail(memberFindPasswordRequestDto);
+        return ResponseEntity.ok().body(Map.of(
+                "message", "임시 비밀번호를 이메일로 전송했습니다."
+        ));
     }
 }

--- a/src/main/java/com/ssafy/questory/dto/request/member/MemberFindPasswordRequestDto.java
+++ b/src/main/java/com/ssafy/questory/dto/request/member/MemberFindPasswordRequestDto.java
@@ -1,0 +1,14 @@
+package com.ssafy.questory.dto.request.member;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class MemberFindPasswordRequestDto {
+    private String email;
+
+    @Builder
+    private MemberFindPasswordRequestDto(String email) {
+        this.email = email;
+    }
+}

--- a/src/main/java/com/ssafy/questory/dto/response/mail/MailResponseDto.java
+++ b/src/main/java/com/ssafy/questory/dto/response/mail/MailResponseDto.java
@@ -1,0 +1,18 @@
+package com.ssafy.questory.dto.response.mail;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class MailResponseDto {
+    private String email;
+    private String title;
+    private String content;
+
+    @Builder
+    private MailResponseDto(String email, String title, String content) {
+        this.email = email;
+        this.title = title;
+        this.content = content;
+    }
+}

--- a/src/main/java/com/ssafy/questory/repository/MemberRepository.java
+++ b/src/main/java/com/ssafy/questory/repository/MemberRepository.java
@@ -2,6 +2,7 @@ package com.ssafy.questory.repository;
 
 import com.ssafy.questory.domain.Member;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 import java.util.Optional;
 
@@ -9,4 +10,5 @@ import java.util.Optional;
 public interface MemberRepository {
     Optional<Member> findByEmail(String email);
     int regist(Member member);
+    int changePassword(@Param("member") Member member, @Param("changedPassword") String changedPassword);
 }

--- a/src/main/java/com/ssafy/questory/service/MailSendService.java
+++ b/src/main/java/com/ssafy/questory/service/MailSendService.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -15,6 +16,7 @@ import org.springframework.stereotype.Service;
 public class MailSendService {
     private final MemberRepository memberRepository;
     private final JavaMailSender mailSender;
+    private final PasswordEncoder passwordEncoder;
 
     @Value("${spring.mail.username}")
     private String fromEmail;
@@ -41,6 +43,7 @@ public class MailSendService {
         String nickname = member.getNickname();
 
         String newPassword = getNewPassword();
+        changePassword(member, newPassword);
 
         return MailResponseDto.builder()
                 .email(email)
@@ -57,5 +60,10 @@ public class MailSendService {
             newPassword.append(idx);
         }
         return newPassword.toString();
+    }
+
+    private void changePassword(Member member, String newPassword) {
+        String encodedPassword = passwordEncoder.encode(newPassword);
+        memberRepository.changePassword(member, encodedPassword);
     }
 }

--- a/src/main/java/com/ssafy/questory/service/MailSendService.java
+++ b/src/main/java/com/ssafy/questory/service/MailSendService.java
@@ -1,0 +1,61 @@
+package com.ssafy.questory.service;
+
+import com.ssafy.questory.domain.Member;
+import com.ssafy.questory.dto.request.member.MemberFindPasswordRequestDto;
+import com.ssafy.questory.dto.response.mail.MailResponseDto;
+import com.ssafy.questory.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MailSendService {
+    private final MemberRepository memberRepository;
+    private final JavaMailSender mailSender;
+
+    @Value("${spring.mail.username}")
+    private String fromEmail;
+
+    private final char[] charSet = new char[] { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F',
+            'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z' };
+
+    public void createAndSendEmail(MemberFindPasswordRequestDto memberFindPasswordRequestDto) {
+        sendEmail(createEmail(memberFindPasswordRequestDto));
+    }
+
+    public void sendEmail(MailResponseDto mailResponseDto) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(mailResponseDto.getEmail());
+        message.setFrom(fromEmail);
+        message.setText(mailResponseDto.getContent());
+        mailSender.send(message);
+    }
+
+    public MailResponseDto createEmail(MemberFindPasswordRequestDto memberFindPasswordRequestDto) {
+        String email = memberFindPasswordRequestDto.getEmail();
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 이메일입니다: " + email));;
+        String nickname = member.getNickname();
+
+        String newPassword = getNewPassword();
+
+        return MailResponseDto.builder()
+                .email(email)
+                .title(nickname + "님의 Questory 임시 비밀번호 안내입니다.")
+                .content("안녕하세요.\nQuestory 임시 비밀번호 안내 드립니다.\n[" + nickname + "]님의 임시 비밀번호는 " + newPassword + "입니다.")
+                .build();
+    }
+
+    public String getNewPassword() {
+        StringBuilder newPassword = new StringBuilder();
+        int idx = 0;
+        for (int i = 0; i < 10; i++) {
+            idx = (int) (charSet.length * Math.random());
+            newPassword.append(idx);
+        }
+        return newPassword.toString();
+    }
+}

--- a/src/main/java/com/ssafy/questory/service/MailSendService.java
+++ b/src/main/java/com/ssafy/questory/service/MailSendService.java
@@ -11,6 +11,8 @@ import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import java.security.SecureRandom;
+
 @Service
 @RequiredArgsConstructor
 public class MailSendService {
@@ -21,8 +23,7 @@ public class MailSendService {
     @Value("${spring.mail.username}")
     private String fromEmail;
 
-    private final char[] charSet = new char[] { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F',
-            'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z' };
+    private final char[] charSet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*".toCharArray();
 
     public void createAndSendEmail(MemberFindPasswordRequestDto memberFindPasswordRequestDto) {
         sendEmail(createEmail(memberFindPasswordRequestDto));
@@ -53,12 +54,14 @@ public class MailSendService {
     }
 
     public String getNewPassword() {
+        SecureRandom random = new SecureRandom();
         StringBuilder newPassword = new StringBuilder();
-        int idx = 0;
-        for (int i = 0; i < 10; i++) {
-            idx = (int) (charSet.length * Math.random());
-            newPassword.append(idx);
+
+        for (int i = 0; i < 12; i++) {
+            int idx = random.nextInt(charSet.length);
+            newPassword.append(charSet[idx]);
         }
+
         return newPassword.toString();
     }
 

--- a/src/main/resources/mappers/Member.xml
+++ b/src/main/resources/mappers/Member.xml
@@ -12,6 +12,11 @@
         FROM Members
         WHERE email = #{email}
     </select>
+    <update id="changePassword" parameterType="map">
+        UPDATE Members
+        SET password = #{changedPassword}
+        WHERE email = #{member.email}
+    </update>
 
     <resultMap id="memberResultMap" type="com.ssafy.questory.domain.Member">
         <id property="email" column="email"/>

--- a/src/test/java/com/ssafy/questory/service/MailSendServiceTest.java
+++ b/src/test/java/com/ssafy/questory/service/MailSendServiceTest.java
@@ -1,0 +1,96 @@
+package com.ssafy.questory.service;
+
+import com.ssafy.questory.domain.Member;
+import com.ssafy.questory.dto.request.member.MemberFindPasswordRequestDto;
+import com.ssafy.questory.repository.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+class MailSendServiceTest {
+
+    private MemberRepository memberRepository;
+    private JavaMailSender mailSender;
+    private PasswordEncoder passwordEncoder;
+
+    private MailSendService mailSendService;
+
+    @BeforeEach
+    void setUp() {
+        memberRepository = mock(MemberRepository.class);
+        mailSender = mock(JavaMailSender.class);
+        passwordEncoder = mock(PasswordEncoder.class);
+        mailSendService = new MailSendService(memberRepository, mailSender, passwordEncoder);
+
+        // 필드 주입 값 설정
+        // reflection을 통한 값 설정 (실제로는 @Value가 주입되지만 테스트에선 직접 설정)
+        try {
+            var field = MailSendService.class.getDeclaredField("fromEmail");
+            field.setAccessible(true);
+            field.set(mailSendService, "noreply@questory.com");
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void createAndSendEmail_정상동작() {
+        // given
+        String email = "test@questory.com";
+        String nickname = "테스터";
+        Member member = Member.builder()
+                .email(email)
+                .password("oldPassword")
+                .nickname(nickname)
+                .build();
+
+        when(memberRepository.findByEmail(email)).thenReturn(Optional.of(member));
+        when(passwordEncoder.encode(anyString())).thenReturn("encodedPassword");
+
+        MemberFindPasswordRequestDto requestDto = MemberFindPasswordRequestDto.builder()
+                .email(email)
+                .build();
+
+        // when
+        mailSendService.createAndSendEmail(requestDto);
+
+        // then
+        verify(memberRepository).changePassword(eq(member), anyString());
+        verify(mailSender).send(any(SimpleMailMessage.class));
+    }
+
+    @Test
+    void getNewPassword_길이와문자검사() {
+        // when
+        String pw = mailSendService.getNewPassword();
+
+        // then
+        assertThat(pw).hasSize(12);
+        assertThat(pw).matches("[A-Za-z0-9!@#$%^&*]+");
+    }
+
+    @Test
+    void createAndSendEmail_없는이메일이면_예외발생() {
+        // given
+        String email = "none@questory.com";
+        when(memberRepository.findByEmail(email)).thenReturn(Optional.empty());
+
+        MemberFindPasswordRequestDto requestDto = MemberFindPasswordRequestDto.builder()
+                .email(email)
+                .build();
+
+        // when & then
+        assertThatThrownBy(() -> mailSendService.createAndSendEmail(requestDto))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("존재하지 않는 이메일");
+    }
+
+}


### PR DESCRIPTION
## 관련 이슈
- resolves: #4 

## 작업 내용
- Google SMTP 적용
- 비밀번호 재발급 후 유저 이메일로 임시 비밀번호 전송
- 전송된 임시 비밀번호로 유저 비밀번호 변경