### PR TITLE
[FEAT] #7 - 회원가입 시 이메일 인증 기능 구현

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,12 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-mail</artifactId>
 		</dependency>
+
+		<!-- Redis -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-redis</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/ssafy/questory/common/util/RedisUtil.java
+++ b/src/main/java/com/ssafy/questory/common/util/RedisUtil.java
@@ -1,0 +1,32 @@
+package com.ssafy.questory.common.util;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+public class RedisUtil {
+
+    private final StringRedisTemplate redisTemplate;
+
+    public String getData(String key){
+        ValueOperations<String,String> valueOperations = redisTemplate.opsForValue();
+        return valueOperations.get(key);
+    }
+    public void setData(String key,String value){
+        ValueOperations<String,String> valueOperations = redisTemplate.opsForValue();
+        valueOperations.set(key,value);
+    }
+    public void setDataExpire(String key,String value,long duration){
+        ValueOperations<String,String> valueOperations = redisTemplate.opsForValue();
+        Duration expireDuration = Duration.ofSeconds(duration);
+        valueOperations.set(key,value,expireDuration);
+    }
+    public void deleteData(String key) {
+        redisTemplate.delete(key);
+    }
+}

--- a/src/main/java/com/ssafy/questory/controller/MemberController.java
+++ b/src/main/java/com/ssafy/questory/controller/MemberController.java
@@ -1,12 +1,15 @@
 package com.ssafy.questory.controller;
 
+import com.ssafy.questory.dto.request.member.EmailVerifyRequestDto;
 import com.ssafy.questory.dto.request.member.MemberEmailRequestDto;
 import com.ssafy.questory.dto.request.member.MemberLoginRequestDto;
 import com.ssafy.questory.dto.request.member.MemberRegistRequestDto;
 import com.ssafy.questory.dto.response.member.MemberRegistResponseDto;
 import com.ssafy.questory.dto.response.member.MemberTokenResponseDto;
-import com.ssafy.questory.service.MailSendService;
+import com.ssafy.questory.service.mail.MailSendService;
 import com.ssafy.questory.service.MemberService;
+import com.ssafy.questory.service.mail.PasswordResetService;
+import com.ssafy.questory.service.mail.VerifyService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -23,6 +26,8 @@ import java.util.Map;
 public class MemberController {
     private final MemberService userService;
     private final MailSendService mailSendService;
+    private final PasswordResetService passwordResetService;
+    private final VerifyService verifyService;
 
     @PostMapping("/regist")
     public ResponseEntity<MemberRegistResponseDto> regist(@RequestBody MemberRegistRequestDto memberRegistRequestDto) {
@@ -38,10 +43,18 @@ public class MemberController {
 
     @PostMapping("/find-password")
     public ResponseEntity<Map<String, String>> findPassword(
-            @RequestBody MemberEmailRequestDto memberFindPasswordRequestDto) {
-        mailSendService.createAndSendEmail(memberFindPasswordRequestDto);
+            @RequestBody MemberEmailRequestDto memberEmailRequestDto) {
+        mailSendService.sendEmail(passwordResetService.buildMail(memberEmailRequestDto));
         return ResponseEntity.ok().body(Map.of(
                 "message", "임시 비밀번호를 이메일로 전송했습니다."
+        ));
+    }
+
+    @PostMapping("send-verify")
+    public ResponseEntity<Map<String, String>> sendVerifyEmail(@RequestBody MemberEmailRequestDto memberEmailRequestDto) {
+        mailSendService.sendEmail(verifyService.buildMail(memberEmailRequestDto));
+        return ResponseEntity.ok().body(Map.of(
+                "message", "인증코드를 이메일로 전송했습니다."
         ));
     }
 }

--- a/src/main/java/com/ssafy/questory/controller/MemberController.java
+++ b/src/main/java/com/ssafy/questory/controller/MemberController.java
@@ -44,15 +44,15 @@ public class MemberController {
     @PostMapping("/find-password")
     public ResponseEntity<Map<String, String>> findPassword(
             @RequestBody MemberEmailRequestDto memberEmailRequestDto) {
-        mailSendService.sendEmail(passwordResetService.buildMail(memberEmailRequestDto));
+        mailSendService.sendEmail(passwordResetService.buildMail(memberEmailRequestDto.getEmail()));
         return ResponseEntity.ok().body(Map.of(
                 "message", "임시 비밀번호를 이메일로 전송했습니다."
         ));
     }
 
     @PostMapping("send-verify")
-    public ResponseEntity<Map<String, String>> sendVerifyEmail(@RequestBody MemberEmailRequestDto memberEmailRequestDto) {
-        mailSendService.sendEmail(verifyService.buildMail(memberEmailRequestDto));
+    public ResponseEntity<Map<String, String>> sendVerifyEmail(@RequestBody EmailVerifyRequestDto emailVerifyRequestDto) {
+        mailSendService.sendEmail(verifyService.buildMail(emailVerifyRequestDto.getEmail()));
         return ResponseEntity.ok().body(Map.of(
                 "message", "인증코드를 이메일로 전송했습니다."
         ));

--- a/src/main/java/com/ssafy/questory/controller/MemberController.java
+++ b/src/main/java/com/ssafy/questory/controller/MemberController.java
@@ -1,6 +1,6 @@
 package com.ssafy.questory.controller;
 
-import com.ssafy.questory.dto.request.member.MemberFindPasswordRequestDto;
+import com.ssafy.questory.dto.request.member.MemberEmailRequestDto;
 import com.ssafy.questory.dto.request.member.MemberLoginRequestDto;
 import com.ssafy.questory.dto.request.member.MemberRegistRequestDto;
 import com.ssafy.questory.dto.response.member.MemberRegistResponseDto;
@@ -38,7 +38,7 @@ public class MemberController {
 
     @PostMapping("/find-password")
     public ResponseEntity<Map<String, String>> findPassword(
-            @RequestBody MemberFindPasswordRequestDto memberFindPasswordRequestDto) {
+            @RequestBody MemberEmailRequestDto memberFindPasswordRequestDto) {
         mailSendService.createAndSendEmail(memberFindPasswordRequestDto);
         return ResponseEntity.ok().body(Map.of(
                 "message", "임시 비밀번호를 이메일로 전송했습니다."

--- a/src/main/java/com/ssafy/questory/controller/MemberController.java
+++ b/src/main/java/com/ssafy/questory/controller/MemberController.java
@@ -50,11 +50,19 @@ public class MemberController {
         ));
     }
 
-    @PostMapping("send-verify")
-    public ResponseEntity<Map<String, String>> sendVerifyEmail(@RequestBody EmailVerifyRequestDto emailVerifyRequestDto) {
-        mailSendService.sendEmail(verifyService.buildMail(emailVerifyRequestDto.getEmail()));
+    @PostMapping("/send-verify")
+    public ResponseEntity<Map<String, String>> sendVerifyEmail(@RequestBody MemberEmailRequestDto memberEmailRequestDto) {
+        mailSendService.sendEmail(verifyService.buildMail(memberEmailRequestDto.getEmail()));
         return ResponseEntity.ok().body(Map.of(
                 "message", "인증코드를 이메일로 전송했습니다."
+        ));
+    }
+
+    @PostMapping("/verify-code")
+    public ResponseEntity<Map<String, String>> verifyCode(@RequestBody EmailVerifyRequestDto emailVerifyRequestDto) {
+        verifyService.checkVerifyCode(emailVerifyRequestDto);
+        return ResponseEntity.ok().body(Map.of(
+                "message", "인증이 완료되었습니다."
         ));
     }
 }

--- a/src/main/java/com/ssafy/questory/dto/request/member/EmailVerifyRequestDto.java
+++ b/src/main/java/com/ssafy/questory/dto/request/member/EmailVerifyRequestDto.java
@@ -1,0 +1,16 @@
+package com.ssafy.questory.dto.request.member;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class EmailVerifyRequestDto {
+    private String email;
+    private String code;
+
+    @Builder
+    private EmailVerifyRequestDto(String email, String code) {
+        this.email = email;
+        this.code = code;
+    }
+}

--- a/src/main/java/com/ssafy/questory/dto/request/member/MemberEmailRequestDto.java
+++ b/src/main/java/com/ssafy/questory/dto/request/member/MemberEmailRequestDto.java
@@ -4,11 +4,11 @@ import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-public class MemberFindPasswordRequestDto {
+public class MemberEmailRequestDto {
     private String email;
 
     @Builder
-    private MemberFindPasswordRequestDto(String email) {
+    private MemberEmailRequestDto(String email) {
         this.email = email;
     }
 }

--- a/src/main/java/com/ssafy/questory/service/MailSendService.java
+++ b/src/main/java/com/ssafy/questory/service/MailSendService.java
@@ -1,7 +1,7 @@
 package com.ssafy.questory.service;
 
 import com.ssafy.questory.domain.Member;
-import com.ssafy.questory.dto.request.member.MemberFindPasswordRequestDto;
+import com.ssafy.questory.dto.request.member.MemberEmailRequestDto;
 import com.ssafy.questory.dto.response.mail.MailResponseDto;
 import com.ssafy.questory.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -25,7 +25,7 @@ public class MailSendService {
 
     private final char[] charSet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*".toCharArray();
 
-    public void createAndSendEmail(MemberFindPasswordRequestDto memberFindPasswordRequestDto) {
+    public void createAndSendEmail(MemberEmailRequestDto memberFindPasswordRequestDto) {
         sendEmail(createEmail(memberFindPasswordRequestDto));
     }
 
@@ -37,7 +37,7 @@ public class MailSendService {
         mailSender.send(message);
     }
 
-    public MailResponseDto createEmail(MemberFindPasswordRequestDto memberFindPasswordRequestDto) {
+    public MailResponseDto createEmail(MemberEmailRequestDto memberFindPasswordRequestDto) {
         String email = memberFindPasswordRequestDto.getEmail();
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 이메일입니다: " + email));;

--- a/src/main/java/com/ssafy/questory/service/mail/MailContentBuilder.java
+++ b/src/main/java/com/ssafy/questory/service/mail/MailContentBuilder.java
@@ -4,5 +4,5 @@ import com.ssafy.questory.dto.request.member.MemberEmailRequestDto;
 import com.ssafy.questory.dto.response.mail.MailResponseDto;
 
 public interface MailContentBuilder {
-    MailResponseDto buildMail(MemberEmailRequestDto memberEmailRequestDto);
+    MailResponseDto buildMail(String email);
 }

--- a/src/main/java/com/ssafy/questory/service/mail/MailContentBuilder.java
+++ b/src/main/java/com/ssafy/questory/service/mail/MailContentBuilder.java
@@ -1,6 +1,5 @@
 package com.ssafy.questory.service.mail;
 
-import com.ssafy.questory.dto.request.member.MemberEmailRequestDto;
 import com.ssafy.questory.dto.response.mail.MailResponseDto;
 
 public interface MailContentBuilder {

--- a/src/main/java/com/ssafy/questory/service/mail/MailContentBuilder.java
+++ b/src/main/java/com/ssafy/questory/service/mail/MailContentBuilder.java
@@ -1,0 +1,8 @@
+package com.ssafy.questory.service.mail;
+
+import com.ssafy.questory.dto.request.member.MemberEmailRequestDto;
+import com.ssafy.questory.dto.response.mail.MailResponseDto;
+
+public interface MailContentBuilder {
+    MailResponseDto buildMail(MemberEmailRequestDto memberEmailRequestDto);
+}

--- a/src/main/java/com/ssafy/questory/service/mail/MailSendService.java
+++ b/src/main/java/com/ssafy/questory/service/mail/MailSendService.java
@@ -1,0 +1,25 @@
+package com.ssafy.questory.service.mail;
+
+import com.ssafy.questory.dto.response.mail.MailResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MailSendService {
+    private final JavaMailSender mailSender;
+
+    @Value("${spring.mail.username}")
+    private String fromEmail;
+
+    public void sendEmail(MailResponseDto mailResponseDto) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(mailResponseDto.getEmail());
+        message.setFrom(fromEmail);
+        message.setText(mailResponseDto.getContent());
+        mailSender.send(message);
+    }
+}

--- a/src/main/java/com/ssafy/questory/service/mail/PasswordResetService.java
+++ b/src/main/java/com/ssafy/questory/service/mail/PasswordResetService.java
@@ -1,7 +1,6 @@
 package com.ssafy.questory.service.mail;
 
 import com.ssafy.questory.domain.Member;
-import com.ssafy.questory.dto.request.member.MemberEmailRequestDto;
 import com.ssafy.questory.dto.response.mail.MailResponseDto;
 import com.ssafy.questory.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/ssafy/questory/service/mail/PasswordResetService.java
+++ b/src/main/java/com/ssafy/questory/service/mail/PasswordResetService.java
@@ -13,6 +13,7 @@ import java.security.SecureRandom;
 @Service
 @RequiredArgsConstructor
 public class PasswordResetService implements MailContentBuilder {
+
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
 
@@ -22,16 +23,30 @@ public class PasswordResetService implements MailContentBuilder {
     public MailResponseDto buildMail(MemberEmailRequestDto memberEmailRequestDto) {
         String email = memberEmailRequestDto.getEmail();
         Member member = memberRepository.findByEmail(email)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 이메일입니다: " + email));;
-        String nickname = member.getNickname();
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 이메일입니다: " + email));
 
         String newPassword = getNewPassword();
         changePassword(member, newPassword);
 
+        String title = "[Questory] 임시 비밀번호 안내드립니다.";
+        String content = String.format("""
+                안녕하세요, Questory입니다.
+
+                회원님의 요청에 따라 임시 비밀번호를 발급해드렸습니다.
+                아래의 임시 비밀번호로 로그인하신 후, 반드시 비밀번호를 변경해 주세요.
+
+                임시 비밀번호: %s
+
+                해당 비밀번호는 보안을 위해 1회성으로 사용되며,
+                타인에게 노출되지 않도록 주의해주시기 바랍니다.
+
+                감사합니다.
+                """, newPassword);
+
         return MailResponseDto.builder()
                 .email(email)
-                .title(nickname + "님의 Questory 임시 비밀번호 안내입니다.")
-                .content("안녕하세요.\nQuestory 임시 비밀번호 안내 드립니다.\n[" + nickname + "]님의 임시 비밀번호는 " + newPassword + "입니다.")
+                .title(title)
+                .content(content)
                 .build();
     }
 

--- a/src/main/java/com/ssafy/questory/service/mail/PasswordResetService.java
+++ b/src/main/java/com/ssafy/questory/service/mail/PasswordResetService.java
@@ -1,13 +1,10 @@
-package com.ssafy.questory.service;
+package com.ssafy.questory.service.mail;
 
 import com.ssafy.questory.domain.Member;
 import com.ssafy.questory.dto.request.member.MemberEmailRequestDto;
 import com.ssafy.questory.dto.response.mail.MailResponseDto;
 import com.ssafy.questory.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.mail.SimpleMailMessage;
-import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -15,30 +12,15 @@ import java.security.SecureRandom;
 
 @Service
 @RequiredArgsConstructor
-public class MailSendService {
+public class PasswordResetService implements MailContentBuilder {
     private final MemberRepository memberRepository;
-    private final JavaMailSender mailSender;
     private final PasswordEncoder passwordEncoder;
-
-    @Value("${spring.mail.username}")
-    private String fromEmail;
 
     private final char[] charSet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*".toCharArray();
 
-    public void createAndSendEmail(MemberEmailRequestDto memberFindPasswordRequestDto) {
-        sendEmail(createEmail(memberFindPasswordRequestDto));
-    }
-
-    public void sendEmail(MailResponseDto mailResponseDto) {
-        SimpleMailMessage message = new SimpleMailMessage();
-        message.setTo(mailResponseDto.getEmail());
-        message.setFrom(fromEmail);
-        message.setText(mailResponseDto.getContent());
-        mailSender.send(message);
-    }
-
-    public MailResponseDto createEmail(MemberEmailRequestDto memberFindPasswordRequestDto) {
-        String email = memberFindPasswordRequestDto.getEmail();
+    @Override
+    public MailResponseDto buildMail(MemberEmailRequestDto memberEmailRequestDto) {
+        String email = memberEmailRequestDto.getEmail();
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 이메일입니다: " + email));;
         String nickname = member.getNickname();

--- a/src/main/java/com/ssafy/questory/service/mail/PasswordResetService.java
+++ b/src/main/java/com/ssafy/questory/service/mail/PasswordResetService.java
@@ -20,8 +20,7 @@ public class PasswordResetService implements MailContentBuilder {
     private final char[] charSet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*".toCharArray();
 
     @Override
-    public MailResponseDto buildMail(MemberEmailRequestDto memberEmailRequestDto) {
-        String email = memberEmailRequestDto.getEmail();
+    public MailResponseDto buildMail(String email) {
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 이메일입니다: " + email));
 

--- a/src/main/java/com/ssafy/questory/service/mail/PasswordResetService.java
+++ b/src/main/java/com/ssafy/questory/service/mail/PasswordResetService.java
@@ -35,7 +35,7 @@ public class PasswordResetService implements MailContentBuilder {
                 .build();
     }
 
-    public String getNewPassword() {
+    private String getNewPassword() {
         SecureRandom random = new SecureRandom();
         StringBuilder newPassword = new StringBuilder();
 

--- a/src/main/java/com/ssafy/questory/service/mail/VerifyService.java
+++ b/src/main/java/com/ssafy/questory/service/mail/VerifyService.java
@@ -1,0 +1,55 @@
+package com.ssafy.questory.service.mail;
+
+import com.ssafy.questory.domain.Member;
+import com.ssafy.questory.dto.request.member.MemberEmailRequestDto;
+import com.ssafy.questory.dto.response.mail.MailResponseDto;
+import com.ssafy.questory.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.security.SecureRandom;
+
+@Service
+@RequiredArgsConstructor
+public class VerifyService implements MailContentBuilder {
+
+    @Override
+    public MailResponseDto buildMail(MemberEmailRequestDto memberEmailRequestDto) {
+        String email = memberEmailRequestDto.getEmail();
+        String verificationCode = generateVerificationCode();
+
+        String title = "[Questory] 이메일 인증 코드 안내";
+        String content = String.format("""
+            안녕하세요, Questory입니다.
+
+            요청하신 이메일 인증 코드를 안내드립니다.
+            회원가입을 완료하려면 아래 인증 코드를 입력해주세요.
+
+            인증 코드: %s
+
+            해당 코드는 5분간 유효하며, 만료 후에는 다시 요청하셔야 합니다.
+
+            감사합니다.
+            """, verificationCode);
+
+        return MailResponseDto.builder()
+                .email(email)
+                .title(title)
+                .content(content)
+                .build();
+    }
+
+    private String generateVerificationCode() {
+        int length = 6;
+        String charSet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+        SecureRandom random = new SecureRandom();
+        StringBuilder code = new StringBuilder();
+
+        for (int i = 0; i < length; i++) {
+            int idx = random.nextInt(charSet.length());
+            code.append(charSet.charAt(idx));
+        }
+
+        return code.toString();
+    }
+}

--- a/src/main/java/com/ssafy/questory/service/mail/VerifyService.java
+++ b/src/main/java/com/ssafy/questory/service/mail/VerifyService.java
@@ -14,8 +14,7 @@ import java.security.SecureRandom;
 public class VerifyService implements MailContentBuilder {
 
     @Override
-    public MailResponseDto buildMail(MemberEmailRequestDto memberEmailRequestDto) {
-        String email = memberEmailRequestDto.getEmail();
+    public MailResponseDto buildMail(String email) {
         String verificationCode = generateVerificationCode();
 
         String title = "[Questory] 이메일 인증 코드 안내";

--- a/src/test/java/com/ssafy/questory/service/MailSendServiceTest.java
+++ b/src/test/java/com/ssafy/questory/service/MailSendServiceTest.java
@@ -1,7 +1,7 @@
 package com.ssafy.questory.service;
 
 import com.ssafy.questory.domain.Member;
-import com.ssafy.questory.dto.request.member.MemberFindPasswordRequestDto;
+import com.ssafy.questory.dto.request.member.MemberEmailRequestDto;
 import com.ssafy.questory.repository.MemberRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -55,7 +55,7 @@ class MailSendServiceTest {
         when(memberRepository.findByEmail(email)).thenReturn(Optional.of(member));
         when(passwordEncoder.encode(anyString())).thenReturn("encodedPassword");
 
-        MemberFindPasswordRequestDto requestDto = MemberFindPasswordRequestDto.builder()
+        MemberEmailRequestDto requestDto = MemberEmailRequestDto.builder()
                 .email(email)
                 .build();
 
@@ -83,7 +83,7 @@ class MailSendServiceTest {
         String email = "none@questory.com";
         when(memberRepository.findByEmail(email)).thenReturn(Optional.empty());
 
-        MemberFindPasswordRequestDto requestDto = MemberFindPasswordRequestDto.builder()
+        MemberEmailRequestDto requestDto = MemberEmailRequestDto.builder()
                 .email(email)
                 .build();
 

--- a/src/test/java/com/ssafy/questory/service/MailSendServiceTest.java
+++ b/src/test/java/com/ssafy/questory/service/MailSendServiceTest.java
@@ -1,96 +1,53 @@
 package com.ssafy.questory.service;
 
-import com.ssafy.questory.domain.Member;
-import com.ssafy.questory.dto.request.member.MemberEmailRequestDto;
-import com.ssafy.questory.repository.MemberRepository;
+import com.ssafy.questory.dto.response.mail.MailResponseDto;
+import com.ssafy.questory.service.mail.MailSendService;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
-import org.springframework.security.crypto.password.PasswordEncoder;
-
-import java.util.Optional;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
 class MailSendServiceTest {
 
-    private MemberRepository memberRepository;
-    private JavaMailSender mailSender;
-    private PasswordEncoder passwordEncoder;
-
+    private JavaMailSender javaMailSender;
     private MailSendService mailSendService;
+
+    private final String fromEmail = "test@questory.com";
 
     @BeforeEach
     void setUp() {
-        memberRepository = mock(MemberRepository.class);
-        mailSender = mock(JavaMailSender.class);
-        passwordEncoder = mock(PasswordEncoder.class);
-        mailSendService = new MailSendService(memberRepository, mailSender, passwordEncoder);
-
-        // 필드 주입 값 설정
-        // reflection을 통한 값 설정 (실제로는 @Value가 주입되지만 테스트에선 직접 설정)
-        try {
-            var field = MailSendService.class.getDeclaredField("fromEmail");
-            field.setAccessible(true);
-            field.set(mailSendService, "noreply@questory.com");
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+        javaMailSender = mock(JavaMailSender.class);
+        mailSendService = new MailSendService(javaMailSender); // ✅ 생성자에는 mailSender만
+        ReflectionTestUtils.setField(mailSendService, "fromEmail", fromEmail); // ✅ fromEmail 직접 주입
     }
 
     @Test
-    void createAndSendEmail_정상동작() {
+    @DisplayName("메일이 정상적으로 전송되어야 한다.")
+    void sendEmail_success() {
         // given
-        String email = "test@questory.com";
-        String nickname = "테스터";
-        Member member = Member.builder()
-                .email(email)
-                .password("oldPassword")
-                .nickname(nickname)
+        MailResponseDto dto = MailResponseDto.builder()
+                .email("receiver@example.com")
+                .title("테스트 제목")
+                .content("테스트 내용")
                 .build();
 
-        when(memberRepository.findByEmail(email)).thenReturn(Optional.of(member));
-        when(passwordEncoder.encode(anyString())).thenReturn("encodedPassword");
-
-        MemberEmailRequestDto requestDto = MemberEmailRequestDto.builder()
-                .email(email)
-                .build();
+        ArgumentCaptor<SimpleMailMessage> messageCaptor = ArgumentCaptor.forClass(SimpleMailMessage.class);
 
         // when
-        mailSendService.createAndSendEmail(requestDto);
+        mailSendService.sendEmail(dto);
 
         // then
-        verify(memberRepository).changePassword(eq(member), anyString());
-        verify(mailSender).send(any(SimpleMailMessage.class));
+        verify(javaMailSender, times(1)).send(messageCaptor.capture());
+
+        SimpleMailMessage sentMessage = messageCaptor.getValue();
+        assertThat(sentMessage.getTo()).containsExactly("receiver@example.com");
+        assertThat(sentMessage.getFrom()).isEqualTo(fromEmail);
+        assertThat(sentMessage.getText()).isEqualTo("테스트 내용");
     }
-
-    @Test
-    void getNewPassword_길이와문자검사() {
-        // when
-        String pw = mailSendService.getNewPassword();
-
-        // then
-        assertThat(pw).hasSize(12);
-        assertThat(pw).matches("[A-Za-z0-9!@#$%^&*]+");
-    }
-
-    @Test
-    void createAndSendEmail_없는이메일이면_예외발생() {
-        // given
-        String email = "none@questory.com";
-        when(memberRepository.findByEmail(email)).thenReturn(Optional.empty());
-
-        MemberEmailRequestDto requestDto = MemberEmailRequestDto.builder()
-                .email(email)
-                .build();
-
-        // when & then
-        assertThatThrownBy(() -> mailSendService.createAndSendEmail(requestDto))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("존재하지 않는 이메일");
-    }
-
 }

--- a/src/test/java/com/ssafy/questory/service/MailSendServiceTest.java
+++ b/src/test/java/com/ssafy/questory/service/MailSendServiceTest.java
@@ -23,8 +23,8 @@ class MailSendServiceTest {
     @BeforeEach
     void setUp() {
         javaMailSender = mock(JavaMailSender.class);
-        mailSendService = new MailSendService(javaMailSender); // ✅ 생성자에는 mailSender만
-        ReflectionTestUtils.setField(mailSendService, "fromEmail", fromEmail); // ✅ fromEmail 직접 주입
+        mailSendService = new MailSendService(javaMailSender);
+        ReflectionTestUtils.setField(mailSendService, "fromEmail", fromEmail);
     }
 
     @Test


### PR DESCRIPTION
## 관련 이슈
- resolves: #7 

## 작업 내용
- 인증 코드 생성 로직 구성
- Google SMTP로 인증 코드 발송한 후, Redis에 이메일을 키로 가지도록 하여 인증 코드 저장
- 사용자가 입력한 인증코드와 발급된 인증 코드가 일치하는지 검증