### PR TITLE
[FIX] Stamp ErrorCode 이름 수정

### DIFF
--- a/src/main/java/com/ssafy/questory/common/exception/ErrorCode.java
+++ b/src/main/java/com/ssafy/questory/common/exception/ErrorCode.java
@@ -23,7 +23,7 @@ public enum ErrorCode {
     INVALID_EMAIL_FORMAT(HttpStatus.BAD_REQUEST, "이메일 형식이 올바르지 않습니다."),
 
     // 스탬프 관련
-    STAMP_NOT_FOUND(HttpStatus.NOT_FOUND, "회원이 보유한 스탬프가 없습니다."),
+    STAMP_LIST_EMPTY(HttpStatus.NO_CONTENT, "회원이 보유한 스탬프가 없습니다."),
 
     // 퀘스트 관련
     ATTRACTION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 관광지가 존재하지 않습니다."),

--- a/src/main/java/com/ssafy/questory/service/StampService.java
+++ b/src/main/java/com/ssafy/questory/service/StampService.java
@@ -19,7 +19,7 @@ public class StampService {
         int offset  = (page-1) * size;
         List<StampsResponseDto> stampsResponseDtoList = stampRepository.findStamps(memberEmail, offset, size);
         if(stampsResponseDtoList.isEmpty()){
-            throw new CustomException(ErrorCode.STAMP_NOT_FOUND);
+            throw new CustomException(ErrorCode.STAMP_LIST_EMPTY);
         }
         return stampsResponseDtoList;
     }

--- a/src/test/java/com/ssafy/questory/service/StampServiceTest.java
+++ b/src/test/java/com/ssafy/questory/service/StampServiceTest.java
@@ -86,7 +86,7 @@ public class StampServiceTest {
         // when & then
         assertThatThrownBy(() -> stampService.findStamps(memberEmail, page, size))
                 .isInstanceOf(CustomException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.STAMP_NOT_FOUND);
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.STAMP_LIST_EMPTY);
 
         verify(stampRepository).findStamps(memberEmail, offset, size);
     }


### PR DESCRIPTION
# 관련 이슈
resolves #26 

# 작업 내용
- 스탬프 조회 시 결과가 0개 일 때, 던지는 ErrorCode의 이름을 STAMP_LIST_EMPTY 로 수정