### PR TITLE
[FEAT] #20 - 여행 계획 관련 CRUD 구현

### DIFF
--- a/src/main/java/com/ssafy/questory/common/exception/ErrorCode.java
+++ b/src/main/java/com/ssafy/questory/common/exception/ErrorCode.java
@@ -33,6 +33,9 @@ public enum ErrorCode {
     QUEST_ALREADY_DELETED(HttpStatus.GONE, "이미 삭제된 퀘스트입니다."),
     QUEST_LIST_EMPTY(HttpStatus.NO_CONTENT, "조회할 퀘스트가 없습니다."),
 
+    // 계획 관련
+    PLAN_NOT_FOUND(HttpStatus.NOT_FOUND, "회원이 생성한 계획이 없습니다."),
+
     // 입력 검증
     VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "입력값이 유효하지 않습니다."),
 

--- a/src/main/java/com/ssafy/questory/controller/PlanController.java
+++ b/src/main/java/com/ssafy/questory/controller/PlanController.java
@@ -1,0 +1,33 @@
+package com.ssafy.questory.controller;
+
+import com.ssafy.questory.domain.Member;
+import com.ssafy.questory.dto.request.plan.PlanCreateRequestDto;
+import com.ssafy.questory.service.PlanService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/plans")
+@RequiredArgsConstructor
+public class PlanController {
+    private final PlanService planService;
+
+    @PostMapping()
+    @Operation(summary = "친구 목록 조회", description = "나의 친구 목록을 조회합니다.")
+    public ResponseEntity<Map<String, String>> create(
+            @AuthenticationPrincipal(expression = "member") Member member,
+            @RequestBody PlanCreateRequestDto planCreateRequestDto) {
+        planService.create(member, planCreateRequestDto);
+        return ResponseEntity.ok().body(Map.of(
+                "message", "여행 계획이 생성되었습니다."
+        ));
+    }
+}

--- a/src/main/java/com/ssafy/questory/controller/PlanController.java
+++ b/src/main/java/com/ssafy/questory/controller/PlanController.java
@@ -3,17 +3,15 @@ package com.ssafy.questory.controller;
 import com.ssafy.questory.domain.Member;
 import com.ssafy.questory.dto.request.plan.PlanCreateRequestDto;
 import com.ssafy.questory.dto.request.plan.PlanDeleteRequestDto;
+import com.ssafy.questory.dto.response.plan.PlanInfoResponseDto;
 import com.ssafy.questory.service.PlanService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.Map;
 
 @RestController
@@ -21,6 +19,13 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class PlanController {
     private final PlanService planService;
+
+    @GetMapping()
+    @Operation(summary = "계획 조회", description = "내 계획을 조회합니다.")
+    public ResponseEntity<List<PlanInfoResponseDto>> getPlanInfo(
+            @AuthenticationPrincipal(expression = "member") Member member) {
+        return ResponseEntity.ok().body(planService.getPlanInfo(member));
+    }
 
     @PostMapping()
     @Operation(summary = "계획 생성", description = "계획을 생성하고 경로를 추가합니다.")

--- a/src/main/java/com/ssafy/questory/controller/PlanController.java
+++ b/src/main/java/com/ssafy/questory/controller/PlanController.java
@@ -2,11 +2,13 @@ package com.ssafy.questory.controller;
 
 import com.ssafy.questory.domain.Member;
 import com.ssafy.questory.dto.request.plan.PlanCreateRequestDto;
+import com.ssafy.questory.dto.request.plan.PlanDeleteRequestDto;
 import com.ssafy.questory.service.PlanService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -28,6 +30,17 @@ public class PlanController {
         planService.create(member, planCreateRequestDto);
         return ResponseEntity.ok().body(Map.of(
                 "message", "여행 계획이 생성되었습니다."
+        ));
+    }
+
+    @DeleteMapping()
+    @Operation(summary = "계획 삭제", description = "생성된 계획을 삭제합니다.")
+    public ResponseEntity<Map<String, String>> delete(
+            @AuthenticationPrincipal(expression = "member") Member member,
+            @RequestBody PlanDeleteRequestDto planDeleteRequestDto) {
+        planService.delete(member, planDeleteRequestDto);
+        return ResponseEntity.ok().body(Map.of(
+                "message", "여행 계획이 삭제되었습니다."
         ));
     }
 }

--- a/src/main/java/com/ssafy/questory/controller/PlanController.java
+++ b/src/main/java/com/ssafy/questory/controller/PlanController.java
@@ -21,7 +21,7 @@ public class PlanController {
     private final PlanService planService;
 
     @PostMapping()
-    @Operation(summary = "친구 목록 조회", description = "나의 친구 목록을 조회합니다.")
+    @Operation(summary = "계획 생성", description = "계획을 생성하고 경로를 추가합니다.")
     public ResponseEntity<Map<String, String>> create(
             @AuthenticationPrincipal(expression = "member") Member member,
             @RequestBody PlanCreateRequestDto planCreateRequestDto) {

--- a/src/main/java/com/ssafy/questory/controller/PlanController.java
+++ b/src/main/java/com/ssafy/questory/controller/PlanController.java
@@ -3,6 +3,7 @@ package com.ssafy.questory.controller;
 import com.ssafy.questory.domain.Member;
 import com.ssafy.questory.dto.request.plan.PlanCreateRequestDto;
 import com.ssafy.questory.dto.request.plan.PlanDeleteRequestDto;
+import com.ssafy.questory.dto.request.plan.PlanUpdateRequestDto;
 import com.ssafy.questory.dto.response.plan.PlanInfoResponseDto;
 import com.ssafy.questory.service.PlanService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -35,6 +36,17 @@ public class PlanController {
         planService.create(member, planCreateRequestDto);
         return ResponseEntity.ok().body(Map.of(
                 "message", "여행 계획이 생성되었습니다."
+        ));
+    }
+
+    @PatchMapping()
+    @Operation(summary = "계획 수정", description = "계획을 수정합니다.")
+    public ResponseEntity<Map<String, String>> update(
+            @AuthenticationPrincipal(expression = "member") Member member,
+            @RequestBody PlanUpdateRequestDto planUpdateRequestDto) {
+        planService.update(member, planUpdateRequestDto);
+        return ResponseEntity.ok().body(Map.of(
+                "message", "여행 계획이 수정되었습니다."
         ));
     }
 

--- a/src/main/java/com/ssafy/questory/domain/Plan.java
+++ b/src/main/java/com/ssafy/questory/domain/Plan.java
@@ -20,12 +20,15 @@ public class Plan {
 
     @Builder
     private Plan(Long planId, String memberEmail, String title, String description,
-                 LocalDate startDate, LocalDate endDate) {
+                 LocalDate startDate, LocalDate endDate, LocalDate createdAt,
+                 boolean isStart) {
         this.planId = planId;
         this.memberEmail = memberEmail;
         this.title = title;
         this.description = description;
         this.startDate = startDate;
         this.endDate = endDate;
+        this.createdAt = createdAt;
+        this.isStart = isStart;
     }
 }

--- a/src/main/java/com/ssafy/questory/domain/Plan.java
+++ b/src/main/java/com/ssafy/questory/domain/Plan.java
@@ -1,0 +1,31 @@
+package com.ssafy.questory.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class Plan {
+    private Long planId;
+    private String memberEmail;
+    private String title;
+    private String description;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private LocalDate createdAt;
+    private boolean isStart;
+
+    protected Plan() {}
+
+    @Builder
+    private Plan(Long planId, String memberEmail, String title, String description,
+                 LocalDate startDate, LocalDate endDate) {
+        this.planId = planId;
+        this.memberEmail = memberEmail;
+        this.title = title;
+        this.description = description;
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
+}

--- a/src/main/java/com/ssafy/questory/domain/Plan.java
+++ b/src/main/java/com/ssafy/questory/domain/Plan.java
@@ -33,4 +33,11 @@ public class Plan {
         this.createdAt = createdAt;
         this.isStart = isStart;
     }
+
+    public void update(String title, String description, LocalDateTime startDate, LocalDateTime endDate) {
+        this.title = title;
+        this.description = description;
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
 }

--- a/src/main/java/com/ssafy/questory/domain/Route.java
+++ b/src/main/java/com/ssafy/questory/domain/Route.java
@@ -1,0 +1,22 @@
+package com.ssafy.questory.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class Route {
+    private Long planId;
+    private Long attractionId;
+    private int day;
+    private int sequence;
+
+    protected Route() {}
+
+    @Builder
+    private Route(Long planId, Long attractionId, int day, int sequence) {
+        this.planId = planId;
+        this.attractionId = attractionId;
+        this.day = day;
+        this.sequence = sequence;
+    }
+}

--- a/src/main/java/com/ssafy/questory/dto/request/plan/PlanCreateRequestDto.java
+++ b/src/main/java/com/ssafy/questory/dto/request/plan/PlanCreateRequestDto.java
@@ -1,0 +1,41 @@
+package com.ssafy.questory.dto.request.plan;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+public class PlanCreateRequestDto {
+    private String title;
+    private String description;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private List<RouteDto> routes;
+
+    @Builder
+    public PlanCreateRequestDto(String title, String description,
+                                LocalDate startDate, LocalDate endDate,
+                                List<RouteDto> routes) {
+        this.title = title;
+        this.description = description;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.routes = routes;
+    }
+
+    @Getter
+    public static class RouteDto {
+        private Long attractionId;
+        private int day;
+        private int sequence;
+
+        @Builder
+        public RouteDto(Long attractionId, int day, int sequence) {
+            this.attractionId = attractionId;
+            this.day = day;
+            this.sequence = sequence;
+        }
+    }
+}

--- a/src/main/java/com/ssafy/questory/dto/request/plan/PlanCreateRequestDto.java
+++ b/src/main/java/com/ssafy/questory/dto/request/plan/PlanCreateRequestDto.java
@@ -3,20 +3,20 @@ package com.ssafy.questory.dto.request.plan;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
 public class PlanCreateRequestDto {
     private String title;
     private String description;
-    private LocalDate startDate;
-    private LocalDate endDate;
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
     private List<RouteDto> routes;
 
     @Builder
     public PlanCreateRequestDto(String title, String description,
-                                LocalDate startDate, LocalDate endDate,
+                                LocalDateTime startDate, LocalDateTime endDate,
                                 List<RouteDto> routes) {
         this.title = title;
         this.description = description;

--- a/src/main/java/com/ssafy/questory/dto/request/plan/PlanDeleteRequestDto.java
+++ b/src/main/java/com/ssafy/questory/dto/request/plan/PlanDeleteRequestDto.java
@@ -1,0 +1,14 @@
+package com.ssafy.questory.dto.request.plan;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class PlanDeleteRequestDto {
+    private Long planId;
+
+    @Builder
+    public PlanDeleteRequestDto(Long planId) {
+        this.planId = planId;
+    }
+}

--- a/src/main/java/com/ssafy/questory/dto/request/plan/PlanUpdateRequestDto.java
+++ b/src/main/java/com/ssafy/questory/dto/request/plan/PlanUpdateRequestDto.java
@@ -1,0 +1,29 @@
+package com.ssafy.questory.dto.request.plan;
+
+import com.ssafy.questory.domain.Route;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+public class PlanUpdateRequestDto {
+    private Long planId;
+    private String title;
+    private String description;
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
+    private List<Route> routes;
+
+    @Builder
+    public PlanUpdateRequestDto(Long planId, String title, String description,
+                                LocalDateTime startDate, LocalDateTime endDate, List<Route> routes) {
+        this.planId = planId;
+        this.title = title;
+        this.description = description;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.routes = routes;
+    }
+}

--- a/src/main/java/com/ssafy/questory/dto/response/plan/PlanInfoResponseDto.java
+++ b/src/main/java/com/ssafy/questory/dto/response/plan/PlanInfoResponseDto.java
@@ -1,14 +1,14 @@
-package com.ssafy.questory.domain;
+package com.ssafy.questory.dto.response.plan;
 
+import com.ssafy.questory.domain.Route;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.ToString;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
-@ToString
-public class Plan {
+public class PlanInfoResponseDto {
     private Long planId;
     private String memberEmail;
     private String title;
@@ -17,13 +17,12 @@ public class Plan {
     private LocalDateTime endDate;
     private LocalDateTime createdAt;
     private boolean isStart;
-
-    protected Plan() {}
+    private List<Route> routes;
 
     @Builder
-    private Plan(Long planId, String memberEmail, String title, String description,
-                 LocalDateTime startDate, LocalDateTime endDate, LocalDateTime createdAt,
-                 boolean isStart) {
+    private PlanInfoResponseDto(Long planId, String memberEmail, String title, String description,
+                                LocalDateTime startDate, LocalDateTime endDate, LocalDateTime createdAt, boolean isStart,
+                                List<Route> routes) {
         this.planId = planId;
         this.memberEmail = memberEmail;
         this.title = title;
@@ -32,5 +31,6 @@ public class Plan {
         this.endDate = endDate;
         this.createdAt = createdAt;
         this.isStart = isStart;
+        this.routes = routes;
     }
 }

--- a/src/main/java/com/ssafy/questory/repository/PlanRepository.java
+++ b/src/main/java/com/ssafy/questory/repository/PlanRepository.java
@@ -3,7 +3,11 @@ package com.ssafy.questory.repository;
 import com.ssafy.questory.domain.Plan;
 import org.apache.ibatis.annotations.Mapper;
 
+import java.util.Optional;
+
 @Mapper
 public interface PlanRepository {
+    Optional<Plan> findById(Long planId);
     int create(Plan plan);
+    int deleteById(Long planId);
 }

--- a/src/main/java/com/ssafy/questory/repository/PlanRepository.java
+++ b/src/main/java/com/ssafy/questory/repository/PlanRepository.java
@@ -11,5 +11,6 @@ public interface PlanRepository {
     List<Plan> findByMemberEmail(String memberEmail);
     Optional<Plan> findById(Long planId);
     int create(Plan plan);
+    int update(Plan plan);
     int deleteById(Long planId);
 }

--- a/src/main/java/com/ssafy/questory/repository/PlanRepository.java
+++ b/src/main/java/com/ssafy/questory/repository/PlanRepository.java
@@ -3,10 +3,12 @@ package com.ssafy.questory.repository;
 import com.ssafy.questory.domain.Plan;
 import org.apache.ibatis.annotations.Mapper;
 
+import java.util.List;
 import java.util.Optional;
 
 @Mapper
 public interface PlanRepository {
+    List<Plan> findByMemberEmail(String memberEmail);
     Optional<Plan> findById(Long planId);
     int create(Plan plan);
     int deleteById(Long planId);

--- a/src/main/java/com/ssafy/questory/repository/PlanRepository.java
+++ b/src/main/java/com/ssafy/questory/repository/PlanRepository.java
@@ -1,0 +1,9 @@
+package com.ssafy.questory.repository;
+
+import com.ssafy.questory.domain.Plan;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface PlanRepository {
+    int create(Plan plan);
+}

--- a/src/main/java/com/ssafy/questory/repository/PlanRoutesRepository.java
+++ b/src/main/java/com/ssafy/questory/repository/PlanRoutesRepository.java
@@ -1,0 +1,12 @@
+package com.ssafy.questory.repository;
+
+import com.ssafy.questory.domain.Route;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+@Mapper
+public interface PlanRoutesRepository {
+    void insert(@Param("routes") List<Route> routes);
+}

--- a/src/main/java/com/ssafy/questory/repository/PlanRoutesRepository.java
+++ b/src/main/java/com/ssafy/questory/repository/PlanRoutesRepository.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 @Mapper
 public interface PlanRoutesRepository {
+    List<Route> findByPlanId(Long planId);
     void insert(@Param("routes") List<Route> routes);
     int deleteByPlanId(Long planId);
 }

--- a/src/main/java/com/ssafy/questory/repository/PlanRoutesRepository.java
+++ b/src/main/java/com/ssafy/questory/repository/PlanRoutesRepository.java
@@ -9,4 +9,5 @@ import java.util.List;
 @Mapper
 public interface PlanRoutesRepository {
     void insert(@Param("routes") List<Route> routes);
+    int deleteByPlanId(Long planId);
 }

--- a/src/main/java/com/ssafy/questory/service/PlanService.java
+++ b/src/main/java/com/ssafy/questory/service/PlanService.java
@@ -1,0 +1,44 @@
+package com.ssafy.questory.service;
+
+import com.ssafy.questory.domain.Member;
+import com.ssafy.questory.domain.Plan;
+import com.ssafy.questory.domain.Route;
+import com.ssafy.questory.dto.request.plan.PlanCreateRequestDto;
+import com.ssafy.questory.repository.PlanRoutesRepository;
+import com.ssafy.questory.repository.PlanRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PlanService {
+    private final PlanRepository planRepository;
+    private final PlanRoutesRepository planRoutesRepository;
+
+    public void create(Member member, PlanCreateRequestDto dto) {
+        // 1. 플랜 생성
+        Plan plan = Plan.builder()
+                .memberEmail(member.getEmail())
+                .title(dto.getTitle())
+                .description(dto.getDescription())
+                .startDate(dto.getStartDate())
+                .endDate(dto.getEndDate())
+                .build();
+        planRepository.create(plan); // planId가 plan에 자동 할당
+
+        // 2. Route 리스트 생성
+        List<Route> routes = dto.getRoutes().stream()
+                .map(routeDto -> Route.builder()
+                        .planId(plan.getPlanId())
+                        .attractionId(routeDto.getAttractionId())
+                        .day(routeDto.getDay())
+                        .sequence(routeDto.getSequence())
+                        .build())
+                .toList();
+
+        // 3. Bulk Insert
+        planRoutesRepository.insert(routes);
+    }
+}

--- a/src/main/java/com/ssafy/questory/service/PlanService.java
+++ b/src/main/java/com/ssafy/questory/service/PlanService.java
@@ -1,9 +1,12 @@
 package com.ssafy.questory.service;
 
+import com.ssafy.questory.common.exception.CustomException;
+import com.ssafy.questory.common.exception.ErrorCode;
 import com.ssafy.questory.domain.Member;
 import com.ssafy.questory.domain.Plan;
 import com.ssafy.questory.domain.Route;
 import com.ssafy.questory.dto.request.plan.PlanCreateRequestDto;
+import com.ssafy.questory.dto.request.plan.PlanDeleteRequestDto;
 import com.ssafy.questory.repository.PlanRoutesRepository;
 import com.ssafy.questory.repository.PlanRepository;
 import lombok.RequiredArgsConstructor;
@@ -37,5 +40,21 @@ public class PlanService {
                 .toList();
 
         planRoutesRepository.insert(routes);
+    }
+
+    public void delete(Member member, PlanDeleteRequestDto planDeleteRequestDto) {
+        Plan plan = planRepository.findById(planDeleteRequestDto.getPlanId())
+                .orElseThrow(() -> new CustomException(ErrorCode.PLAN_NOT_FOUND));
+
+        validateAuthorizedMember(plan.getMemberEmail(), member.getEmail());
+
+        planRoutesRepository.deleteByPlanId(planDeleteRequestDto.getPlanId());
+        planRepository.deleteById(planDeleteRequestDto.getPlanId());
+    }
+
+    private void validateAuthorizedMember(String email1, String email2) {
+        if (!email1.equals(email2)) {
+            throw new CustomException(ErrorCode.TOKEN_NOT_FOUND);
+        }
     }
 }

--- a/src/main/java/com/ssafy/questory/service/PlanService.java
+++ b/src/main/java/com/ssafy/questory/service/PlanService.java
@@ -18,7 +18,6 @@ public class PlanService {
     private final PlanRoutesRepository planRoutesRepository;
 
     public void create(Member member, PlanCreateRequestDto dto) {
-        // 1. 플랜 생성
         Plan plan = Plan.builder()
                 .memberEmail(member.getEmail())
                 .title(dto.getTitle())
@@ -26,9 +25,8 @@ public class PlanService {
                 .startDate(dto.getStartDate())
                 .endDate(dto.getEndDate())
                 .build();
-        planRepository.create(plan); // planId가 plan에 자동 할당
+        planRepository.create(plan);
 
-        // 2. Route 리스트 생성
         List<Route> routes = dto.getRoutes().stream()
                 .map(routeDto -> Route.builder()
                         .planId(plan.getPlanId())
@@ -38,7 +36,6 @@ public class PlanService {
                         .build())
                 .toList();
 
-        // 3. Bulk Insert
         planRoutesRepository.insert(routes);
     }
 }

--- a/src/main/java/com/ssafy/questory/service/PlanService.java
+++ b/src/main/java/com/ssafy/questory/service/PlanService.java
@@ -7,6 +7,7 @@ import com.ssafy.questory.domain.Plan;
 import com.ssafy.questory.domain.Route;
 import com.ssafy.questory.dto.request.plan.PlanCreateRequestDto;
 import com.ssafy.questory.dto.request.plan.PlanDeleteRequestDto;
+import com.ssafy.questory.dto.response.plan.PlanInfoResponseDto;
 import com.ssafy.questory.repository.PlanRoutesRepository;
 import com.ssafy.questory.repository.PlanRepository;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +20,28 @@ import java.util.List;
 public class PlanService {
     private final PlanRepository planRepository;
     private final PlanRoutesRepository planRoutesRepository;
+
+    public List<PlanInfoResponseDto> getPlanInfo(Member member) {
+        List<Plan> plans = planRepository.findByMemberEmail(member.getEmail());
+        System.out.println(plans);
+        return plans.stream()
+                .map(plan -> {
+                    List<Route> routes = planRoutesRepository.findByPlanId(plan.getPlanId());
+                    return PlanInfoResponseDto.builder()
+                            .planId(plan.getPlanId())
+                            .memberEmail(plan.getMemberEmail())
+                            .title(plan.getTitle())
+                            .description(plan.getDescription())
+                            .startDate(plan.getStartDate())
+                            .endDate(plan.getEndDate())
+                            .createdAt(plan.getCreatedAt())
+                            .isStart(plan.isStart())
+                            .routes(routes)
+                            .build();
+                })
+                .toList();
+    }
+
 
     public void create(Member member, PlanCreateRequestDto dto) {
         Plan plan = Plan.builder()

--- a/src/main/resources/mappers/PlanRoute.xml
+++ b/src/main/resources/mappers/PlanRoute.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.ssafy.questory.repository.PlanRoutesRepository">
+    <insert id="insert" parameterType="list">
+        INSERT INTO Plans_Routes (plan_id, attraction_id, day, sequence)
+        VALUES
+        <foreach collection="routes" item="route" separator=",">
+            (#{route.planId}, #{route.attractionId}, #{route.day}, #{route.sequence})
+        </foreach>
+    </insert>
+</mapper>

--- a/src/main/resources/mappers/PlanRoute.xml
+++ b/src/main/resources/mappers/PlanRoute.xml
@@ -10,4 +10,7 @@
             (#{route.planId}, #{route.attractionId}, #{route.day}, #{route.sequence})
         </foreach>
     </insert>
+    <delete id="deleteByPlanId" parameterType="long">
+        DELETE FROM Plans_Routes WHERE plan_id = #{planId}
+    </delete>
 </mapper>

--- a/src/main/resources/mappers/PlanRoute.xml
+++ b/src/main/resources/mappers/PlanRoute.xml
@@ -3,6 +3,15 @@
         PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.ssafy.questory.repository.PlanRoutesRepository">
+    <select id="findByPlanId" parameterType="long" resultType="com.ssafy.questory.domain.Route">
+        SELECT
+        plan_id AS planId,
+        attraction_id AS attractionId,
+        day,
+        sequence
+        FROM Plans_Routes
+        WHERE plan_id = #{planId}
+    </select>
     <insert id="insert" parameterType="list">
         INSERT INTO Plans_Routes (plan_id, attraction_id, day, sequence)
         VALUES

--- a/src/main/resources/mappers/plan.xml
+++ b/src/main/resources/mappers/plan.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.ssafy.questory.repository.PlanRepository">
+    <insert id="create" parameterType="com.ssafy.questory.domain.Plan" useGeneratedKeys="true" keyProperty="planId">
+        INSERT INTO Plans (member_email, title, description, start_date, end_date, created_at, is_start)
+        VALUES (#{memberEmail}, #{title}, #{description}, #{startDate}, #{endDate}, NOW(), 0)
+    </insert>
+</mapper>

--- a/src/main/resources/mappers/plan.xml
+++ b/src/main/resources/mappers/plan.xml
@@ -7,4 +7,20 @@
         INSERT INTO Plans (member_email, title, description, start_date, end_date, created_at, is_start)
         VALUES (#{memberEmail}, #{title}, #{description}, #{startDate}, #{endDate}, NOW(), 0)
     </insert>
+    <select id="findById" parameterType="long" resultMap="planResultMap">
+        SELECT * FROM Plans WHERE plan_id = #{planId}
+    </select>
+    <resultMap id="planResultMap" type="com.ssafy.questory.domain.Plan">
+        <id property="planId" column="plan_id"/>
+        <result property="memberEmail" column="member_email"/>
+        <result property="title" column="title"/>
+        <result property="description" column="description"/>
+        <result property="startDate" column="start_date"/>
+        <result property="endDate" column="end_date"/>
+        <result property="createdAt" column="created_at"/>
+        <result property="isStart" column="is_start"/>
+    </resultMap>
+    <delete id="deleteById" parameterType="long">
+        DELETE FROM Plans WHERE plan_id = #{planId}
+    </delete>
 </mapper>

--- a/src/main/resources/mappers/plan.xml
+++ b/src/main/resources/mappers/plan.xml
@@ -20,6 +20,14 @@
         INSERT INTO Plans (member_email, title, description, start_date, end_date, created_at, is_start)
         VALUES (#{memberEmail}, #{title}, #{description}, #{startDate}, #{endDate}, NOW(), 0)
     </insert>
+    <update id="update" parameterType="com.ssafy.questory.domain.Plan">
+        UPDATE Plans
+        SET title = #{title},
+        description = #{description},
+        start_date = #{startDate},
+        end_date = #{endDate}
+        WHERE plan_id = #{planId}
+    </update>
     <select id="findById" parameterType="long" resultMap="planResultMap">
         SELECT * FROM Plans WHERE plan_id = #{planId}
     </select>

--- a/src/main/resources/mappers/plan.xml
+++ b/src/main/resources/mappers/plan.xml
@@ -3,6 +3,19 @@
         PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.ssafy.questory.repository.PlanRepository">
+    <select id="findByMemberEmail" parameterType="string" resultType="com.ssafy.questory.domain.Plan">
+        SELECT
+        plan_id AS planId,
+        member_email AS memberEmail,
+        title,
+        description,
+        start_date AS startDate,
+        end_date AS endDate,
+        created_at AS createdAt,
+        is_start AS isStart
+        FROM Plans
+        WHERE member_email = #{memberEmail}
+    </select>
     <insert id="create" parameterType="com.ssafy.questory.domain.Plan" useGeneratedKeys="true" keyProperty="planId">
         INSERT INTO Plans (member_email, title, description, start_date, end_date, created_at, is_start)
         VALUES (#{memberEmail}, #{title}, #{description}, #{startDate}, #{endDate}, NOW(), 0)

--- a/src/test/java/com/ssafy/questory/service/PlanServiceTest.java
+++ b/src/test/java/com/ssafy/questory/service/PlanServiceTest.java
@@ -7,6 +7,7 @@ import com.ssafy.questory.domain.Plan;
 import com.ssafy.questory.domain.Route;
 import com.ssafy.questory.dto.request.plan.PlanCreateRequestDto;
 import com.ssafy.questory.dto.request.plan.PlanDeleteRequestDto;
+import com.ssafy.questory.dto.request.plan.PlanUpdateRequestDto;
 import com.ssafy.questory.dto.response.plan.PlanInfoResponseDto;
 import com.ssafy.questory.repository.PlanRepository;
 import com.ssafy.questory.repository.PlanRoutesRepository;
@@ -128,6 +129,58 @@ class PlanServiceTest {
 
         // then
         verify(planRepository).create(any(Plan.class));
+        verify(planRoutesRepository).insert(anyList());
+    }
+
+    @Test
+    @DisplayName("여행 계획 업데이트 성공")
+    void testUpdatePlan() {
+        // given
+        String memberEmail = "user@example.com";
+        Member member = Member.builder().email(memberEmail).build();
+
+        Long planId = 1L;
+
+        Plan plan = Plan.builder()
+                .planId(planId)
+                .memberEmail(memberEmail)
+                .title("Old Title")
+                .description("Old Desc")
+                .startDate(LocalDateTime.now())
+                .endDate(LocalDateTime.now().plusDays(1))
+                .build();
+
+        // 직접 Route 사용
+        Route route1 = Route.builder()
+                .planId(planId)
+                .attractionId(101L)
+                .day(1)
+                .sequence(1)
+                .build();
+
+        PlanUpdateRequestDto requestDto = PlanUpdateRequestDto.builder()
+                .planId(planId)
+                .title("New Title")
+                .description("New Desc")
+                .startDate(LocalDateTime.now().plusDays(1))
+                .endDate(LocalDateTime.now().plusDays(2))
+                .routes(List.of(route1))
+                .build();
+
+        when(planRepository.findById(planId)).thenReturn(Optional.of(plan));
+
+        // when
+        planService.update(member, requestDto);
+
+        // then
+        assertThat(plan.getTitle()).isEqualTo("New Title");
+        assertThat(plan.getDescription()).isEqualTo("New Desc");
+        assertThat(plan.getStartDate()).isEqualTo(requestDto.getStartDate());
+        assertThat(plan.getEndDate()).isEqualTo(requestDto.getEndDate());
+
+        verify(planRepository).findById(planId);
+        verify(planRepository).update(plan);
+        verify(planRoutesRepository).deleteByPlanId(planId);
         verify(planRoutesRepository).insert(anyList());
     }
 

--- a/src/test/java/com/ssafy/questory/service/PlanServiceTest.java
+++ b/src/test/java/com/ssafy/questory/service/PlanServiceTest.java
@@ -1,0 +1,209 @@
+package com.ssafy.questory.service;
+
+import com.ssafy.questory.common.exception.CustomException;
+import com.ssafy.questory.common.exception.ErrorCode;
+import com.ssafy.questory.domain.Member;
+import com.ssafy.questory.domain.Plan;
+import com.ssafy.questory.domain.Route;
+import com.ssafy.questory.dto.request.plan.PlanCreateRequestDto;
+import com.ssafy.questory.dto.request.plan.PlanDeleteRequestDto;
+import com.ssafy.questory.dto.response.plan.PlanInfoResponseDto;
+import com.ssafy.questory.repository.PlanRepository;
+import com.ssafy.questory.repository.PlanRoutesRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class PlanServiceTest {
+
+    private PlanRepository planRepository;
+    private PlanRoutesRepository planRoutesRepository;
+    private PlanService planService;
+
+    @BeforeEach
+    void setUp() {
+        planRepository = mock(PlanRepository.class);
+        planRoutesRepository = mock(PlanRoutesRepository.class);
+        planService = new PlanService(planRepository, planRoutesRepository);
+    }
+
+    @Test
+    @DisplayName("getPlanInfo: 회원의 모든 계획과 각 계획의 경로 목록을 조회한다")
+    void getPlanInfoTest() {
+        // given
+        Member member = Member.builder().email("test@domain.com").build();
+
+        Plan plan1 = Plan.builder()
+                .planId(1L)
+                .memberEmail(member.getEmail())
+                .title("여행1")
+                .description("설명1")
+                .startDate(LocalDateTime.of(2025, 5, 20, 10, 0))
+                .endDate(LocalDateTime.of(2025, 5, 21, 20, 0))
+                .createdAt(LocalDateTime.of(2025, 5, 19, 9, 0))
+                .isStart(false)
+                .build();
+
+        Plan plan2 = Plan.builder()
+                .planId(2L)
+                .memberEmail(member.getEmail())
+                .title("여행2")
+                .description("설명2")
+                .startDate(LocalDateTime.of(2025, 6, 1, 8, 0))
+                .endDate(LocalDateTime.of(2025, 6, 2, 22, 0))
+                .createdAt(LocalDateTime.of(2025, 5, 25, 12, 0))
+                .isStart(true)
+                .build();
+
+        Route route1 = Route.builder().planId(1L).attractionId(101L).day(1).sequence(1).build();
+        Route route2 = Route.builder().planId(1L).attractionId(102L).day(1).sequence(2).build();
+        Route route3 = Route.builder().planId(2L).attractionId(201L).day(2).sequence(1).build();
+
+        when(planRepository.findByMemberEmail(member.getEmail()))
+                .thenReturn(List.of(plan1, plan2));
+
+        when(planRoutesRepository.findByPlanId(1L))
+                .thenReturn(List.of(route1, route2));
+        when(planRoutesRepository.findByPlanId(2L))
+                .thenReturn(List.of(route3));
+
+        // when
+        List<PlanInfoResponseDto> result = planService.getPlanInfo(member);
+
+        // then
+        assertThat(result).hasSize(2);
+
+        PlanInfoResponseDto planDto1 = result.get(0);
+        assertThat(planDto1.getPlanId()).isEqualTo(1L);
+        assertThat(planDto1.getRoutes()).hasSize(2);
+        assertThat(planDto1.getRoutes().get(0).getAttractionId()).isEqualTo(101L);
+
+        PlanInfoResponseDto planDto2 = result.get(1);
+        assertThat(planDto2.getPlanId()).isEqualTo(2L);
+        assertThat(planDto2.getRoutes()).hasSize(1);
+        assertThat(planDto2.getRoutes().get(0).getAttractionId()).isEqualTo(201L);
+
+        verify(planRepository).findByMemberEmail(member.getEmail());
+        verify(planRoutesRepository).findByPlanId(1L);
+        verify(planRoutesRepository).findByPlanId(2L);
+    }
+
+    @Test
+    @DisplayName("create: 회원의 계획 및 경로를 저장한다")
+    void createTest() {
+        // given
+        Member member = Member.builder().email("test@domain.com").build();
+
+        // PlanCreateRequestDto.RouteDto를 빌더로 생성
+        PlanCreateRequestDto.RouteDto routeDto1 = PlanCreateRequestDto.RouteDto.builder()
+                .attractionId(101L).day(1).sequence(1).build();
+        PlanCreateRequestDto.RouteDto routeDto2 = PlanCreateRequestDto.RouteDto.builder()
+                .attractionId(102L).day(1).sequence(2).build();
+
+        PlanCreateRequestDto dto = PlanCreateRequestDto.builder()
+                .title("여행1")
+                .description("설명1")
+                .startDate(LocalDateTime.of(2025, 5, 20, 10, 0))
+                .endDate(LocalDateTime.of(2025, 5, 21, 20, 0))
+                .routes(List.of(routeDto1, routeDto2))
+                .build();
+
+        // PlanRepository.create(plan) 실행 시, plan에 id가 채워지도록 모킹
+        doAnswer(invocation -> {
+            Plan plan = invocation.getArgument(0);
+            // 실제로는 plan.setPlanId(1L) 등을 할 수 있는데, builder 패턴이면 불가. insert 호출만 검증!
+            return 1;
+        }).when(planRepository).create(any(Plan.class));
+
+        // when
+        planService.create(member, dto);
+
+        // then
+        verify(planRepository).create(any(Plan.class));
+        verify(planRoutesRepository).insert(anyList());
+    }
+
+
+    @Test
+    @DisplayName("delete: 권한 있는 회원이 계획을 정상적으로 삭제한다")
+    void deleteTest() {
+        // given
+        Member member = Member.builder().email("test@domain.com").build();
+        long planId = 1L;
+        Plan plan = Plan.builder()
+                .planId(planId)
+                .memberEmail(member.getEmail())
+                .build();
+
+        PlanDeleteRequestDto dto = PlanDeleteRequestDto.builder()
+                .planId(planId)
+                .build();
+
+        when(planRepository.findById(planId)).thenReturn(Optional.of(plan));
+
+        // when
+        planService.delete(member, dto);
+
+        // then
+        verify(planRoutesRepository).deleteByPlanId(planId);
+        verify(planRepository).deleteById(planId);
+    }
+
+    @Test
+    @DisplayName("delete: 다른 사용자가 계획 삭제를 시도하면 예외가 발생한다")
+    void delete_throwsExceptionWhenUnauthorized() {
+        // given
+        Member member = Member.builder().email("user1@domain.com").build();
+        long planId = 1L;
+        // plan.owner와 member.email 다름
+        Plan plan = Plan.builder()
+                .planId(planId)
+                .memberEmail("user2@domain.com")
+                .build();
+
+        PlanDeleteRequestDto dto = PlanDeleteRequestDto.builder()
+                .planId(planId)
+                .build();
+
+        when(planRepository.findById(planId)).thenReturn(Optional.of(plan));
+
+        // when, then
+        assertThatThrownBy(() -> planService.delete(member, dto))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(ErrorCode.TOKEN_NOT_FOUND.getMessage());
+
+        // deleteByPlanId, deleteById는 호출되면 안 됨
+        verify(planRoutesRepository, never()).deleteByPlanId(anyLong());
+        verify(planRepository, never()).deleteById(anyLong());
+    }
+
+    @Test
+    @DisplayName("delete: 없는 계획을 삭제하려 하면 예외가 발생한다")
+    void delete_throwsExceptionWhenNotFound() {
+        // given
+        Member member = Member.builder().email("user1@domain.com").build();
+        long planId = 1L;
+
+        PlanDeleteRequestDto dto = PlanDeleteRequestDto.builder()
+                .planId(planId)
+                .build();
+
+        when(planRepository.findById(planId)).thenReturn(Optional.empty());
+
+        // when, then
+        assertThatThrownBy(() -> planService.delete(member, dto))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(ErrorCode.PLAN_NOT_FOUND.getMessage());
+
+        verify(planRoutesRepository, never()).deleteByPlanId(anyLong());
+        verify(planRepository, never()).deleteById(anyLong());
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- resolves: #20 

## 작업 내용
- 계획 생성 및 경로 추가 기능 구현
- 계획 삭제 기능 구현
- 계획 조회 기능 구현
- 계획 수정 기능 구현

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 여행 계획(플랜) 생성, 조회, 수정, 삭제 기능이 추가되었습니다. 사용자는 자신의 여행 계획을 관리할 수 있습니다.

- **버그 수정**
    - 사용자가 생성한 계획이 존재하지 않을 때를 처리하는 오류 코드가 추가되었습니다.

- **문서화**
    - API 명세에 여행 계획 관련 엔드포인트가 추가되었습니다.

- **테스트**
    - 여행 계획 서비스의 주요 기능(생성, 조회, 수정, 삭제 및 예외 처리)에 대한 단위 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->