### PR TITLE
[FEAT] #32 - 경로 공유 및 저장 기능 구현

### DIFF
--- a/src/main/java/com/ssafy/questory/common/exception/ErrorCode.java
+++ b/src/main/java/com/ssafy/questory/common/exception/ErrorCode.java
@@ -36,6 +36,9 @@ public enum ErrorCode {
     // 계획, 경로 관련
     PLAN_NOT_FOUND(HttpStatus.NOT_FOUND, "회원이 생성한 계획이 없습니다."),
     ALREADY_SHARED_PLAN(HttpStatus.BAD_REQUEST, "이미 공유된 계획입니다."),
+    PLAN_NOT_SHARED(HttpStatus.BAD_REQUEST, "공유되지 않은 계획입니다."),
+    CANNOT_COPY_OWN_PLAN(HttpStatus.BAD_REQUEST, "자신의 계획은 복사할 수 없습니다."),
+    ALREADY_COPIED_PLAN(HttpStatus.BAD_REQUEST, "이미 복사된 계획입니다."),
 
     // 입력 검증
     VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "입력값이 유효하지 않습니다."),

--- a/src/main/java/com/ssafy/questory/common/exception/ErrorCode.java
+++ b/src/main/java/com/ssafy/questory/common/exception/ErrorCode.java
@@ -33,8 +33,9 @@ public enum ErrorCode {
     QUEST_ALREADY_DELETED(HttpStatus.GONE, "이미 삭제된 퀘스트입니다."),
     QUEST_LIST_EMPTY(HttpStatus.NO_CONTENT, "조회할 퀘스트가 없습니다."),
 
-    // 계획 관련
+    // 계획, 경로 관련
     PLAN_NOT_FOUND(HttpStatus.NOT_FOUND, "회원이 생성한 계획이 없습니다."),
+    ALREADY_SHARED_PLAN(HttpStatus.BAD_REQUEST, "이미 공유된 계획입니다."),
 
     // 입력 검증
     VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "입력값이 유효하지 않습니다."),

--- a/src/main/java/com/ssafy/questory/controller/PlanController.java
+++ b/src/main/java/com/ssafy/questory/controller/PlanController.java
@@ -60,4 +60,13 @@ public class PlanController {
                 "message", "여행 계획이 삭제되었습니다."
         ));
     }
+
+    @PatchMapping("/{planId}/share/toggle")
+    @Operation(summary = "공유 상태 토글", description = "공유 상태를 반전시킵니다.")
+    public ResponseEntity<Map<String, String>> toggleShareStatus(
+            @AuthenticationPrincipal(expression = "member") Member member,
+            @PathVariable Long planId) {
+        planService.toggleShareStatus(member, planId);
+        return ResponseEntity.ok(Map.of("message", "공유 상태가 변경되었습니다."));
+    }
 }

--- a/src/main/java/com/ssafy/questory/controller/PlanController.java
+++ b/src/main/java/com/ssafy/questory/controller/PlanController.java
@@ -69,4 +69,13 @@ public class PlanController {
         planService.toggleShareStatus(member, planId);
         return ResponseEntity.ok(Map.of("message", "공유 상태가 변경되었습니다."));
     }
+
+    @PostMapping("/{planId}/copy")
+    @Operation(summary = "계획 복사", description = "공유된 계획을 복사합니다.")
+    public ResponseEntity<Map<String, String>> copy(
+            @AuthenticationPrincipal (expression = "member") Member member,
+            @PathVariable Long planId) {
+        planService.copy(member, planId);
+        return ResponseEntity.ok(Map.of("message", "계획이 저장되었습니다."));
+    }
 }

--- a/src/main/java/com/ssafy/questory/domain/Plan.java
+++ b/src/main/java/com/ssafy/questory/domain/Plan.java
@@ -17,13 +17,14 @@ public class Plan {
     private LocalDateTime endDate;
     private LocalDateTime createdAt;
     private boolean isStart;
+    private boolean isShared;
 
     protected Plan() {}
 
     @Builder
     private Plan(Long planId, String memberEmail, String title, String description,
                  LocalDateTime startDate, LocalDateTime endDate, LocalDateTime createdAt,
-                 boolean isStart) {
+                 boolean isStart, boolean isShared) {
         this.planId = planId;
         this.memberEmail = memberEmail;
         this.title = title;
@@ -32,6 +33,7 @@ public class Plan {
         this.endDate = endDate;
         this.createdAt = createdAt;
         this.isStart = isStart;
+        this.isShared = isShared;
     }
 
     public void update(String title, String description, LocalDateTime startDate, LocalDateTime endDate) {

--- a/src/main/java/com/ssafy/questory/domain/SavedPlan.java
+++ b/src/main/java/com/ssafy/questory/domain/SavedPlan.java
@@ -1,0 +1,22 @@
+package com.ssafy.questory.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class SavedPlan {
+    private String memberEmail;
+    private Long planId;
+    private LocalDateTime savedAt;
+
+    protected SavedPlan() {}
+
+    @Builder
+    private SavedPlan(String memberEmail, Long planId, LocalDateTime savedAt) {
+        this.memberEmail = memberEmail;
+        this.planId = planId;
+        this.savedAt = savedAt;
+    }
+}

--- a/src/main/java/com/ssafy/questory/dto/response/plan/PlanInfoResponseDto.java
+++ b/src/main/java/com/ssafy/questory/dto/response/plan/PlanInfoResponseDto.java
@@ -17,11 +17,13 @@ public class PlanInfoResponseDto {
     private LocalDateTime endDate;
     private LocalDateTime createdAt;
     private boolean isStart;
+    private boolean isShared;
     private List<Route> routes;
 
     @Builder
     private PlanInfoResponseDto(Long planId, String memberEmail, String title, String description,
-                                LocalDateTime startDate, LocalDateTime endDate, LocalDateTime createdAt, boolean isStart,
+                                LocalDateTime startDate, LocalDateTime endDate, LocalDateTime createdAt,
+                                boolean isStart, boolean isShared,
                                 List<Route> routes) {
         this.planId = planId;
         this.memberEmail = memberEmail;
@@ -31,6 +33,7 @@ public class PlanInfoResponseDto {
         this.endDate = endDate;
         this.createdAt = createdAt;
         this.isStart = isStart;
+        this.isShared = isShared;
         this.routes = routes;
     }
 }

--- a/src/main/java/com/ssafy/questory/repository/PlanRepository.java
+++ b/src/main/java/com/ssafy/questory/repository/PlanRepository.java
@@ -2,6 +2,7 @@ package com.ssafy.questory.repository;
 
 import com.ssafy.questory.domain.Plan;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -12,5 +13,6 @@ public interface PlanRepository {
     Optional<Plan> findById(Long planId);
     int create(Plan plan);
     int update(Plan plan);
+    int toggleShareStatus(@Param("planId") Long planId, @Param("shared") boolean isShared);
     int deleteById(Long planId);
 }

--- a/src/main/java/com/ssafy/questory/repository/SavedRepository.java
+++ b/src/main/java/com/ssafy/questory/repository/SavedRepository.java
@@ -1,0 +1,10 @@
+package com.ssafy.questory.repository;
+
+import com.ssafy.questory.domain.SavedPlan;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface SavedRepository {
+    SavedPlan findBySavedPlan(Long planId, String memberEmail);
+    int copy(Long planId, String memberEmail);
+}

--- a/src/main/java/com/ssafy/questory/service/PlanService.java
+++ b/src/main/java/com/ssafy/questory/service/PlanService.java
@@ -37,6 +37,7 @@ public class PlanService {
                             .endDate(plan.getEndDate())
                             .createdAt(plan.getCreatedAt())
                             .isStart(plan.isStart())
+                            .isShared(plan.isShared())
                             .routes(routes)
                             .build();
                 })
@@ -102,6 +103,16 @@ public class PlanService {
 
         planRoutesRepository.deleteByPlanId(planDeleteRequestDto.getPlanId());
         planRepository.deleteById(planDeleteRequestDto.getPlanId());
+    }
+
+    public void toggleShareStatus(Member member, Long planId) {
+        Plan plan = planRepository.findById(planId)
+                .orElseThrow(() -> new CustomException(ErrorCode.PLAN_NOT_FOUND));
+
+        validateAuthorizedMember(plan.getMemberEmail(), member.getEmail());
+
+        boolean newStatus = !plan.isShared();
+        planRepository.toggleShareStatus(planId, newStatus);
     }
 
     private void validateAuthorizedMember(String email1, String email2) {

--- a/src/main/java/com/ssafy/questory/service/PlanService.java
+++ b/src/main/java/com/ssafy/questory/service/PlanService.java
@@ -11,6 +11,7 @@ import com.ssafy.questory.dto.request.plan.PlanUpdateRequestDto;
 import com.ssafy.questory.dto.response.plan.PlanInfoResponseDto;
 import com.ssafy.questory.repository.PlanRoutesRepository;
 import com.ssafy.questory.repository.PlanRepository;
+import com.ssafy.questory.repository.SavedRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -21,6 +22,7 @@ import java.util.List;
 public class PlanService {
     private final PlanRepository planRepository;
     private final PlanRoutesRepository planRoutesRepository;
+    private final SavedRepository savedRepository;
 
     public List<PlanInfoResponseDto> getPlanInfo(Member member) {
         List<Plan> plans = planRepository.findByMemberEmail(member.getEmail());
@@ -113,6 +115,22 @@ public class PlanService {
 
         boolean newStatus = !plan.isShared();
         planRepository.toggleShareStatus(planId, newStatus);
+    }
+
+    public void copy(Member member, Long planId) {
+        Plan plan = planRepository.findById(planId)
+                .orElseThrow(() -> new CustomException(ErrorCode.PLAN_NOT_FOUND));
+
+        if (!plan.isShared()) {
+            throw new CustomException(ErrorCode.PLAN_NOT_SHARED);
+        }
+        if (member.getEmail().equals(plan.getMemberEmail())) {
+            throw new CustomException(ErrorCode.CANNOT_COPY_OWN_PLAN);
+        }
+        if (savedRepository.findBySavedPlan(planId, member.getEmail()) != null) {
+            throw new CustomException(ErrorCode.ALREADY_COPIED_PLAN);
+        }
+        savedRepository.copy(planId, member.getEmail());
     }
 
     private void validateAuthorizedMember(String email1, String email2) {

--- a/src/main/resources/mappers/Saved.xml
+++ b/src/main/resources/mappers/Saved.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.ssafy.questory.repository.SavedRepository">
+
+    <resultMap id="SavedPlanResultMap" type="com.ssafy.questory.domain.SavedPlan">
+        <id property="planId" column="plan_id"/>
+        <result property="memberEmail" column="member_email"/>
+        <result property="savedAt" column="saved_at"/>
+    </resultMap>
+
+    <select id="findBySavedPlan" resultMap="SavedPlanResultMap">
+        SELECT *
+        FROM saves
+        WHERE plan_id = #{planId}
+        AND member_email = #{memberEmail}
+    </select>
+
+    <insert id="copy">
+        INSERT INTO saves (member_email, plan_id, saved_at)
+        VALUES (#{memberEmail}, #{planId}, NOW())
+    </insert>
+
+</mapper>

--- a/src/main/resources/mappers/plan.xml
+++ b/src/main/resources/mappers/plan.xml
@@ -12,7 +12,8 @@
         start_date AS startDate,
         end_date AS endDate,
         created_at AS createdAt,
-        is_start AS isStart
+        is_start AS isStart,
+        is_shared AS isShared
         FROM Plans
         WHERE member_email = #{memberEmail}
     </select>
@@ -40,8 +41,14 @@
         <result property="endDate" column="end_date"/>
         <result property="createdAt" column="created_at"/>
         <result property="isStart" column="is_start"/>
+        <result property="isShared" column="is_shared"/>
     </resultMap>
     <delete id="deleteById" parameterType="long">
         DELETE FROM Plans WHERE plan_id = #{planId}
     </delete>
+    <update id="toggleShareStatus">
+        UPDATE plans
+        SET is_shared = #{shared}
+        WHERE plan_id = #{planId}
+    </update>
 </mapper>

--- a/src/main/resources/sql/questory.sql
+++ b/src/main/resources/sql/questory.sql
@@ -49,7 +49,14 @@ CREATE TABLE Plans (
     start_date DATETIME,
     end_date DATETIME,
     created_at DATETIME DEFAULT NOW(),
-    is_start TINYINT(1) DEFAULT 0
+    is_start TINYINT(1) DEFAULT 0,
+    is_shared TINYINT(1) DEFAULT 0
+);
+
+CREATE TABLE Saves (
+    member_email VARCHAR(40),
+    plan_id INT,
+    saved_at DATETIME DEFAULT NOW()
 );
 
 CREATE TABLE Routes (
@@ -88,7 +95,7 @@ CREATE TABLE Quests (
     title VARCHAR(100),
     quest_description VARCHAR(10000) NULL,
     difficulty ENUM('EASY', 'MEDIUM', 'HARD') DEFAULT 'MEDIUM',
-	created_at	DATETIME NOT NULL DEFAULT NOW(),
+    created_at    DATETIME NOT NULL DEFAULT NOW(),
     is_private TINYINT(1) DEFAULT 0,
     content_type_id int NOT NULL,
     stamp_description TEXT NULL,


### PR DESCRIPTION
## 관련 이슈
- resolves: #32 

## 작업 내용
- 계획 공유 기능 구현
- 공유된 계획 저장 기능 구현


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 플랜(계획) 공유 상태를 토글하는 기능이 추가되었습니다.
    - 다른 사용자의 공유된 플랜을 복사할 수 있는 기능이 추가되었습니다.
- **개선 사항**
    - 플랜 정보에 공유 여부(isShared)가 표시됩니다.
- **버그 수정**
    - 없음
- **데이터베이스**
    - 플랜 테이블에 공유 여부 컬럼이 추가되었습니다.
    - 플랜 복사 내역을 저장하는 새로운 테이블이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->