### PR TITLE
[FEAT] #44 - 이메일을 통한 유저 검색 기능 구현 

### DIFF
--- a/src/main/java/com/ssafy/questory/controller/MemberController.java
+++ b/src/main/java/com/ssafy/questory/controller/MemberController.java
@@ -1,10 +1,8 @@
 package com.ssafy.questory.controller;
 
-import com.ssafy.questory.dto.request.member.EmailVerifyRequestDto;
-import com.ssafy.questory.dto.request.member.MemberEmailRequestDto;
-import com.ssafy.questory.dto.request.member.MemberLoginRequestDto;
-import com.ssafy.questory.dto.request.member.MemberRegistRequestDto;
+import com.ssafy.questory.dto.request.member.*;
 import com.ssafy.questory.dto.response.member.MemberRegistResponseDto;
+import com.ssafy.questory.dto.response.member.MemberSearchResponseDto;
 import com.ssafy.questory.dto.response.member.MemberTokenResponseDto;
 import com.ssafy.questory.service.mail.MailSendService;
 import com.ssafy.questory.service.MemberService;
@@ -13,12 +11,10 @@ import com.ssafy.questory.service.mail.VerifyService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
 
@@ -72,5 +68,12 @@ public class MemberController {
         return ResponseEntity.ok().body(Map.of(
                 "message", "인증이 완료되었습니다."
         ));
+    }
+
+    @GetMapping("/search")
+    @Operation(summary = "유저 검색", description = "이메일을 통해 유저를 검색합니다.")
+    public ResponseEntity<Page<MemberSearchResponseDto>> search(
+            @ModelAttribute MemberSearchRequestDto memberSearchRequestDto) {
+        return ResponseEntity.ok(userService.search(memberSearchRequestDto));
     }
 }

--- a/src/main/java/com/ssafy/questory/domain/Member.java
+++ b/src/main/java/com/ssafy/questory/domain/Member.java
@@ -22,17 +22,20 @@ public class Member {
     protected Member() {}
 
     @Builder
-    private Member(String email, String password, String nickname) {
+    private Member(String email, String password, String nickname,
+                   Long exp, String title, LocalDate createdAt,
+                   boolean isAdmin, boolean mode, boolean isDeleted,
+                   String profileUrl) {
         this.email = email;
         this.password = password;
         this.nickname = nickname;
-        this.exp = 0L;
-        this.title = "";
-        this.createdAt = LocalDate.now();
-        this.isAdmin = false;
-        this.mode = false;
-        this.isDeleted = false;
-        this.profileUrl = "";
+        this.exp = exp != null ? exp : 0L;
+        this.title = title != null ? title : "";
+        this.createdAt = createdAt != null ? createdAt : LocalDate.now();
+        this.isAdmin = isAdmin;
+        this.mode = mode;
+        this.isDeleted = isDeleted;
+        this.profileUrl = profileUrl != null ? profileUrl : "";
     }
 
     public void modify(MemberModifyRequestDto memberModifyRequestDto) {

--- a/src/main/java/com/ssafy/questory/dto/request/member/MemberSearchRequestDto.java
+++ b/src/main/java/com/ssafy/questory/dto/request/member/MemberSearchRequestDto.java
@@ -1,0 +1,18 @@
+package com.ssafy.questory.dto.request.member;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class MemberSearchRequestDto {
+    private String email;
+    private int page;
+    private int size;
+
+    @Builder
+    public MemberSearchRequestDto(String email, int page, int size) {
+        this.email = email;
+        this.page = page;
+        this.size = size;
+    }
+}

--- a/src/main/java/com/ssafy/questory/dto/response/member/MemberSearchResponseDto.java
+++ b/src/main/java/com/ssafy/questory/dto/response/member/MemberSearchResponseDto.java
@@ -1,0 +1,26 @@
+package com.ssafy.questory.dto.response.member;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class MemberSearchResponseDto {
+    private String email;
+    private String nickname;
+    private String profileImageUrl;
+
+    @Builder
+    private MemberSearchResponseDto(String email, String nickname, String profileImageUrl) {
+        this.email = email;
+        this.nickname = nickname;
+        this.profileImageUrl = profileImageUrl;
+    }
+
+    public static MemberSearchResponseDto from(String email, String nickname, String profileImageUrl) {
+        return MemberSearchResponseDto.builder()
+                .email(email)
+                .nickname(nickname)
+                .profileImageUrl(profileImageUrl)
+                .build();
+    }
+}

--- a/src/main/java/com/ssafy/questory/repository/MemberRepository.java
+++ b/src/main/java/com/ssafy/questory/repository/MemberRepository.java
@@ -2,9 +2,11 @@ package com.ssafy.questory.repository;
 
 import com.ssafy.questory.domain.Member;
 import com.ssafy.questory.dto.request.member.MemberModifyRequestDto;
+import com.ssafy.questory.dto.response.member.MemberSearchResponseDto;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 @Mapper
@@ -14,4 +16,6 @@ public interface MemberRepository {
     int changePassword(@Param("member") Member member, @Param("changedPassword") String changedPassword);
     int modify(Member member);
     int withdraw(Member member);
+    List<Member> searchByEmailWithPaging(@Param("email") String email, @Param("offset") int offset, @Param("limit") int limit);
+    int countByEmail(@Param("email") String email);
 }

--- a/src/main/resources/mappers/Member.xml
+++ b/src/main/resources/mappers/Member.xml
@@ -42,4 +42,16 @@
         <result property="profileUrl" column="profile_image_url"/>
     </resultMap>
 
+    <select id="searchByEmailWithPaging" resultType="com.ssafy.questory.domain.Member">
+        SELECT *
+        FROM members
+        WHERE email LIKE CONCAT('%', #{email}, '%')
+        LIMIT #{limit} OFFSET #{offset}
+    </select>
+
+    <select id="countByEmail" resultType="int">
+        SELECT COUNT(*)
+        FROM members
+        WHERE email LIKE CONCAT('%', #{email}, '%')
+    </select>
 </mapper>

--- a/src/test/java/com/ssafy/questory/service/PlanServiceTest.java
+++ b/src/test/java/com/ssafy/questory/service/PlanServiceTest.java
@@ -11,6 +11,7 @@ import com.ssafy.questory.dto.request.plan.PlanUpdateRequestDto;
 import com.ssafy.questory.dto.response.plan.PlanInfoResponseDto;
 import com.ssafy.questory.repository.PlanRepository;
 import com.ssafy.questory.repository.PlanRoutesRepository;
+import com.ssafy.questory.repository.SavedRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -27,13 +28,16 @@ class PlanServiceTest {
 
     private PlanRepository planRepository;
     private PlanRoutesRepository planRoutesRepository;
+    private SavedRepository savedRepository;
     private PlanService planService;
 
     @BeforeEach
     void setUp() {
         planRepository = mock(PlanRepository.class);
         planRoutesRepository = mock(PlanRoutesRepository.class);
-        planService = new PlanService(planRepository, planRoutesRepository);
+        savedRepository = mock(SavedRepository.class);
+
+        planService = new PlanService(planRepository, planRoutesRepository, savedRepository);
     }
 
     @Test


### PR DESCRIPTION
## 관련 이슈
- resolves: #44 

## 작업 내용
- 이메일을 통한 유저 검색 기능 구현 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 이메일로 회원을 검색할 수 있는 엔드포인트가 추가되었습니다. 검색 결과는 페이지네이션이 지원됩니다.

- **버그 수정**
    - 해당 없음

- **테스트**
    - 이메일 검색 및 페이지네이션 기능에 대한 단위 테스트가 추가되었습니다.

- **기타**
    - 회원 생성 시 더 다양한 초기 상태를 지정할 수 있도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->