### PR TITLE
[FEAT] #48 - 생성한 퀘스트 리스트 조회 기능 구현

### DIFF
--- a/src/main/java/com/ssafy/questory/domain/Stamp.java
+++ b/src/main/java/com/ssafy/questory/domain/Stamp.java
@@ -3,10 +3,12 @@ package com.ssafy.questory.domain;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@ToString
 public class Stamp {
     private int stampId;
     private String imageUrl;

--- a/src/main/java/com/ssafy/questory/dto/request/quest/QuestRequestDto.java
+++ b/src/main/java/com/ssafy/questory/dto/request/quest/QuestRequestDto.java
@@ -4,9 +4,11 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
 @Builder
+@ToString
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class QuestRequestDto {
     private int attractionId;
@@ -15,16 +17,4 @@ public class QuestRequestDto {
     private String difficulty;
     private Boolean isPrivate;
     private String stampDescription;
-
-    @Override
-    public String toString() {
-        return "QuestRequestDto{" +
-                "attractionId=" + attractionId +
-                ", title='" + title + '\'' +
-                ", questDescription='" + questDescription + '\'' +
-                ", difficulty='" + difficulty + '\'' +
-                ", isPrivate=" + isPrivate +
-                ", stampDescription='" + stampDescription + '\'' +
-                '}';
-    }
 }

--- a/src/main/java/com/ssafy/questory/dto/response/attraction/AttractionResponseDto.java
+++ b/src/main/java/com/ssafy/questory/dto/response/attraction/AttractionResponseDto.java
@@ -3,21 +3,14 @@ package com.ssafy.questory.dto.response.attraction;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.ToString;
 
 @Getter
 @Setter
 @Builder
+@ToString
 public class AttractionResponseDto {
     private int attractionId;
     private String name;
     private String address;
-
-    @Override
-    public String toString() {
-        return "AttractionResponseDto{" +
-                "attractionId=" + attractionId +
-                ", name='" + name + '\'' +
-                ", address='" + address + '\'' +
-                '}';
-    }
 }

--- a/src/main/java/com/ssafy/questory/dto/response/quest/QuestResponseDto.java
+++ b/src/main/java/com/ssafy/questory/dto/response/quest/QuestResponseDto.java
@@ -3,10 +3,12 @@ package com.ssafy.questory.dto.response.quest;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.ToString;
 
 @Getter
 @Setter
 @Builder
+@ToString
 public class QuestResponseDto {
     private int questId;
     private int attractionId;
@@ -17,19 +19,4 @@ public class QuestResponseDto {
     private String questDescription;
     private String stampDescription;
     private boolean isPrivate;
-
-    @Override
-    public String toString() {
-        return "QuestResponseDto{" +
-                "questId=" + questId +
-                ", attractionId=" + attractionId +
-                ", attractionName='" + attractionName + '\'' +
-                ", attractionAddr='" + attractionAddr + '\'' +
-                ", questTitle='" + questTitle + '\'' +
-                ", questDifficulty='" + questDifficulty + '\'' +
-                ", questDescription='" + questDescription + '\'' +
-                ", stampDescription='" + stampDescription + '\'' +
-                ", isPrivate=" + isPrivate +
-                '}';
-    }
 }

--- a/src/main/java/com/ssafy/questory/dto/response/quest/QuestsResponseDto.java
+++ b/src/main/java/com/ssafy/questory/dto/response/quest/QuestsResponseDto.java
@@ -3,12 +3,14 @@ package com.ssafy.questory.dto.response.quest;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.ToString;
 
 import java.time.LocalDate;
 
 @Getter
 @Setter
 @Builder
+@ToString
 public class QuestsResponseDto {
     private int questId;
     private String questTitle;
@@ -18,18 +20,4 @@ public class QuestsResponseDto {
     private String attractionAddress;
     private String questDifficulty;
     private String questDescription;
-
-    @Override
-    public String toString() {
-        return "QuestsResponseDto{" +
-                "questId=" + questId +
-                ", questTitle='" + questTitle + '\'' +
-                ", attractionImage='" + attractionImage + '\'' +
-                ", attractionTitle='" + attractionTitle + '\'' +
-                ", contentTypeName='" + contentTypeName + '\'' +
-                ", attractionAddress='" + attractionAddress + '\'' +
-                ", questDifficulty='" + questDifficulty + '\'' +
-                ", questDescription='" + questDescription + '\'' +
-                '}';
-    }
 }

--- a/src/main/java/com/ssafy/questory/dto/response/quest/QuestsResponseDto.java
+++ b/src/main/java/com/ssafy/questory/dto/response/quest/QuestsResponseDto.java
@@ -10,6 +10,7 @@ import java.time.LocalDate;
 @Setter
 @Builder
 public class QuestsResponseDto {
+    private int questId;
     private String questTitle;
     private String attractionImage;
     private String attractionTitle;
@@ -21,7 +22,8 @@ public class QuestsResponseDto {
     @Override
     public String toString() {
         return "QuestsResponseDto{" +
-                "questTitle='" + questTitle + '\'' +
+                "questId=" + questId +
+                ", questTitle='" + questTitle + '\'' +
                 ", attractionImage='" + attractionImage + '\'' +
                 ", attractionTitle='" + attractionTitle + '\'' +
                 ", contentTypeName='" + contentTypeName + '\'' +

--- a/src/main/java/com/ssafy/questory/dto/response/stamp/StampsResponseDto.java
+++ b/src/main/java/com/ssafy/questory/dto/response/stamp/StampsResponseDto.java
@@ -7,6 +7,7 @@ import java.time.LocalDate;
 @Getter
 @Setter
 @Builder
+@ToString
 public class StampsResponseDto {
 
     private String title;
@@ -16,17 +17,4 @@ public class StampsResponseDto {
     private String sidoName;
     private String difficulty;
     private String description;
-
-    @Override
-    public String toString() {
-        return "StampsResponseDto{" +
-                "title='" + title + '\'' +
-                ", contentTypeId='" + contentTypeId + '\'' +
-                ", date=" + date +
-                ", contentTypeName='" + contentTypeName + '\'' +
-                ", sidoName='" + sidoName + '\'' +
-                ", difficulty='" + difficulty + '\'' +
-                ", description='" + description + '\'' +
-                '}';
-    }
 }

--- a/src/main/java/com/ssafy/questory/repository/QuestRepository.java
+++ b/src/main/java/com/ssafy/questory/repository/QuestRepository.java
@@ -16,13 +16,21 @@ public interface QuestRepository {
 
     int getTotalQuests();
 
-    List<QuestsResponseDto> findQuestsByMemberEmail(@Param("memberEmail") String memberEmail, @Param("offset") int offset, @Param("limit") int limit);
+    List<QuestsResponseDto> findValidQuestsByMemberEmail(@Param("memberEmail") String memberEmail, @Param("offset") int offset, @Param("limit") int limit);
 
     int getTotalQuestsByMemberEmail(@Param("memberEmail") String memberEmail);
 
     List<QuestsResponseDto> findQuestsByMemberEmailAndDifficulty(@Param("memberEmail") String memberEmail, @Param("difficulty") String difficulty, @Param("offset") int offset, @Param("limit") int limit);
 
     int getTotalQuestsByMemberEmailAndDifficulty(@Param("memberEmail") String memberEmail, @Param("difficulty") String difficulty);
+
+    List<QuestsResponseDto> findQuestsCreatedByMe(@Param("memberEmail") String memberEmail, @Param("offset") int offset, @Param("limit") int limit);
+
+    int getTotalQuestsCreatedByMe(@Param("memberEmail") String memberEmail);
+
+    List<QuestsResponseDto> findQuestsCreatedByMeAndDifficulty(@Param("memberEmail") String memberEmail, @Param("difficulty") String difficulty, @Param("offset") int offset, @Param("limit") int limit);
+
+    int getTotalQuestsCreatedByMeAndDifficulty(@Param("memberEmail") String memberEmail, @Param("difficulty") String difficulty);
 
     void saveQuest(@Param("questRequestDto") QuestRequestDto questRequestDto, @Param("memberEmail") String memberEmail, @Param("contentTypeId") int contentTypeId);
 

--- a/src/main/java/com/ssafy/questory/service/QuestService.java
+++ b/src/main/java/com/ssafy/questory/service/QuestService.java
@@ -3,7 +3,6 @@ package com.ssafy.questory.service;
 import com.ssafy.questory.common.exception.CustomException;
 import com.ssafy.questory.common.exception.ErrorCode;
 import com.ssafy.questory.dto.request.quest.QuestRequestDto;
-import com.ssafy.questory.dto.response.attraction.AttractionResponseDto;
 import com.ssafy.questory.dto.response.quest.QuestResponseDto;
 import com.ssafy.questory.dto.response.quest.QuestsResponseDto;
 import com.ssafy.questory.repository.QuestRepository;
@@ -31,11 +30,11 @@ public class QuestService {
         return questRepository.getTotalQuests();
     }
 
-    public List<QuestsResponseDto> findQuestsByMemberEmail(String memberEmail, String difficulty, int page, int size) {
+    public List<QuestsResponseDto> findValidQuestsByMemberEmail(String memberEmail, String difficulty, int page, int size) {
         int offset  = (page-1) * size;
         List<QuestsResponseDto> questsResponseDtoList;
         if(difficulty== null || difficulty.equals("all")){
-            questsResponseDtoList = questRepository.findQuestsByMemberEmail(memberEmail, offset, size);
+            questsResponseDtoList = questRepository.findValidQuestsByMemberEmail(memberEmail, offset, size);
         }else{
             questsResponseDtoList = questRepository.findQuestsByMemberEmailAndDifficulty(memberEmail, difficulty, offset, size);
         }
@@ -51,6 +50,32 @@ public class QuestService {
             return questRepository.getTotalQuestsByMemberEmail(memberEmail);
         }else{
             return questRepository.getTotalQuestsByMemberEmailAndDifficulty(memberEmail, difficulty);
+        }
+    }
+
+
+    public List<QuestsResponseDto> findQuestsCreatedByMe(String memberEmail, String difficulty, int page, int size) {
+        // memberEmail 검증하는 코드 추가하기
+
+        int offset  = (page-1) * size;
+        List<QuestsResponseDto> questsResponseDtoList;
+        if(difficulty== null || difficulty.equals("all")){
+            questsResponseDtoList = questRepository.findQuestsCreatedByMe(memberEmail, offset, size);
+        }else{
+            questsResponseDtoList = questRepository.findQuestsCreatedByMeAndDifficulty(memberEmail, difficulty, offset, size);
+        }
+
+        if(questsResponseDtoList.isEmpty()){
+            throw new CustomException(ErrorCode.QUEST_LIST_EMPTY);
+        }
+        return questsResponseDtoList;
+    }
+
+    public int findQuestsCreatedByMe(String memberEmail, String difficulty) {
+        if(difficulty== null || difficulty.equals("all")){
+            return questRepository.getTotalQuestsCreatedByMe(memberEmail);
+        }else{
+            return questRepository.getTotalQuestsCreatedByMeAndDifficulty(memberEmail, difficulty);
         }
     }
 

--- a/src/main/resources/mappers/Quest.xml
+++ b/src/main/resources/mappers/Quest.xml
@@ -29,7 +29,7 @@
         SELECT count(*) FROM quests WHERE is_deleted = 0 AND is_private = 0;
     </select>
 
-    <select id="findQuestsByMemberEmail" resultMap="questsMap" resultType="com.ssafy.questory.dto.response.quest.QuestsResponseDto">
+    <select id="findValidQuestsByMemberEmail" resultMap="questsMap" resultType="com.ssafy.questory.dto.response.quest.QuestsResponseDto">
         SELECT
         q.title AS quest_title,
         a.first_image1 AS attraction_image,
@@ -97,6 +97,62 @@
             ON q.location_quest_id = mq.location_quest_id
         WHERE
             (mq.is_completed = 'YET' OR mq.is_completed IS NULL) AND  q.is_deleted = 0 AND q.is_private = 0 AND difficulty=#{difficulty};
+    </select>
+
+    <select id="findQuestsCreatedByMe" resultMap="questsMap">
+        SELECT
+            q.title AS quest_title,
+            a.first_image1 AS attraction_image,
+            a.title AS attraction_title,
+            ct.content_type_name AS content_type_name,
+            a.addr1 AS attraction_address,
+            q.difficulty AS quest_difficulty,
+            q.quest_description AS quest_description
+        FROM quests q
+        JOIN
+        attractions a
+        ON q.content_type_id = a.content_type_id AND q.attraction_id = a.no
+        JOIN
+        contenttypes ct
+        ON a.content_type_id = ct.content_type_id
+        WHERE member_email = #{memberEmail} AND is_deleted = 0
+        LIMIT #{offset}, #{limit};
+    </select>
+
+    <select id="getTotalQuestsCreatedByMe">
+        SELECT COUNT(*)
+        FROM quests q
+        WHERE member_email = #{memberEmail} AND is_deleted = 0;
+    </select>
+
+    <select id="findQuestsCreatedByMeAndDifficulty" resultMap="questsMap">
+        SELECT
+            q.title AS quest_title,
+            a.first_image1 AS attraction_image,
+            a.title AS attraction_title,
+            ct.content_type_name AS content_type_name,
+            a.addr1 AS attraction_address,
+            q.difficulty AS quest_difficulty,
+            q.quest_description AS quest_description
+        FROM quests q
+        JOIN
+            attractions a
+            ON q.content_type_id = a.content_type_id AND q.attraction_id = a.no
+        JOIN
+            contenttypes ct
+            ON a.content_type_id = ct.content_type_id
+        WHERE
+            member_email = #{memberEmail} AND is_deleted = 0 AND difficulty = #{difficulty}
+        LIMIT #{offset}, #{limit};
+    </select>
+
+    <select id="getTotalQuestsCreatedByMeAndDifficulty">
+        SELECT
+            COUNT(*)
+        FROM
+            quests q
+        WHERE
+            member_email = #{memberEmail} AND is_deleted = 0 AND difficulty = #{difficulty};
     </select>
 
     <select id="saveQuest">

--- a/src/main/resources/mappers/Quest.xml
+++ b/src/main/resources/mappers/Quest.xml
@@ -7,6 +7,7 @@
 
     <select id="findQuests" resultMap="questsMap" resultType="com.ssafy.questory.dto.response.quest.QuestsResponseDto">
         SELECT
+            q.location_quest_id AS quest_id,
             q.title AS quest_title,
             a.first_image1 AS attraction_image,
             a.title AS attraction_title,
@@ -31,6 +32,7 @@
 
     <select id="findValidQuestsByMemberEmail" resultMap="questsMap" resultType="com.ssafy.questory.dto.response.quest.QuestsResponseDto">
         SELECT
+        q.location_quest_id AS quest_id,
         q.title AS quest_title,
         a.first_image1 AS attraction_image,
         a.title AS attraction_title,
@@ -66,6 +68,7 @@
 
     <select id="findQuestsByMemberEmailAndDifficulty" resultMap="questsMap" resultType="com.ssafy.questory.dto.response.quest.QuestsResponseDto">
         SELECT
+        q.location_quest_id AS quest_id,
         q.title AS quest_title,
         a.first_image1 AS attraction_image,
         a.title AS attraction_title,
@@ -101,6 +104,7 @@
 
     <select id="findQuestsCreatedByMe" resultMap="questsMap">
         SELECT
+            q.location_quest_id AS quest_id,
             q.title AS quest_title,
             a.first_image1 AS attraction_image,
             a.title AS attraction_title,
@@ -127,6 +131,7 @@
 
     <select id="findQuestsCreatedByMeAndDifficulty" resultMap="questsMap">
         SELECT
+            q.location_quest_id AS quest_id,
             q.title AS quest_title,
             a.first_image1 AS attraction_image,
             a.title AS attraction_title,
@@ -249,6 +254,7 @@
     </select>
 
     <resultMap type="QuestsResponseDto" id="questsMap">
+        <result column="location_quest_id" property="questId" />
         <result column="quest_title" property="questTitle" />
         <result column="attraction_image" property="attractionImage" />
         <result column="attraction_title" property="attractionTitle" />

--- a/src/test/java/com/ssafy/questory/service/QuestServiceTest.java
+++ b/src/test/java/com/ssafy/questory/service/QuestServiceTest.java
@@ -1,436 +1,436 @@
-package com.ssafy.questory.service;
-
-import com.ssafy.questory.common.exception.CustomException;
-import com.ssafy.questory.common.exception.ErrorCode;
-import com.ssafy.questory.dto.request.quest.QuestRequestDto;
-import com.ssafy.questory.dto.response.quest.QuestsResponseDto;
-import com.ssafy.questory.repository.QuestRepository;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
-
-class QuestServiceTest {
-
-    private QuestRepository questRepository = mock(QuestRepository.class);
-    private QuestService questService;
-
-    private List<QuestsResponseDto> mockQuests;
-
-    @BeforeEach
-    void setUp() {
-        questService = new QuestService(questRepository);
-
-        QuestsResponseDto quest1 = QuestsResponseDto.builder()
-                .questTitle("title1")
-                .attractionImage("url1")
-                .attractionTitle("name1")
-                .contentTypeName("contentType1")
-                .attractionAddress("addr1")
-                .questDifficulty("EASY")
-                .questDescription("description1")
-                .build();
-
-        QuestsResponseDto quest2 = QuestsResponseDto.builder()
-                .questTitle("title2")
-                .attractionImage("url2")
-                .attractionTitle("name2")
-                .contentTypeName("contentType2")
-                .attractionAddress("addr2")
-                .questDifficulty("EASY")
-                .questDescription("description2")
-                .build();
-        mockQuests = Arrays.asList(quest1, quest2);
-    }
-
-    @Test
-    @DisplayName("전체 퀘스트 목록 조회 성공")
-    void findQuests_ReturnsQuestList() {
-        // given
-        int page = 1;
-        int size = 5;
-        int offset = (page - 1) * size;
-
-        when(questRepository.findQuests(offset, size)).thenReturn(mockQuests);
-
-        // when
-        List<QuestsResponseDto> result = questService.findQuests(page, size);
-
-        // then
-        assertNotNull(result);
-        assertEquals(mockQuests.size(), result.size());
-        verify(questRepository, times(1)).findQuests(offset, size);
-    }
-
-    @Test
-    @DisplayName("퀘스트 목록이 비어있을 경우 예외 발생")
-    void findQuests_ThrowsException_WhenQuestListEmpty() {
-        // given
-        int page = 1;
-        int size = 10;
-        int offset = (page - 1) * size;
-
-        when(questRepository.findQuests(offset, size)).thenReturn(new ArrayList<>());
-
-        // when & then
-        CustomException exception = assertThrows(CustomException.class, () -> {
-            questService.findQuests(page, size);
-        });
-
-        assertEquals(ErrorCode.QUEST_LIST_EMPTY, exception.getErrorCode());
-        verify(questRepository, times(1)).findQuests(offset, size);
-    }
-
-    @Test
-    @DisplayName("전체 퀘스트 수 반환")
-    void getTotalQuests_ReturnsTotalCount() {
-        // given
-        int expectedTotal = 15;
-        when(questRepository.getTotalQuests()).thenReturn(expectedTotal);
-
-        // when
-        int result = questService.getTotalQuests();
-
-        // then
-        assertEquals(expectedTotal, result);
-        verify(questRepository, times(1)).getTotalQuests();
-    }
-
-    @Test
-    @DisplayName("특정 회원이 실행 가능한 퀘스트 목록 조회 - 전체 난이도")
-    void findQuestsByMemberEmail_ReturnsQuestList() {
-        // given
-        String testEmail = "test@example.com";
-
-        int page = 1;
-        int size = 5;
-        int offset = (page - 1) * size;
-        String difficulty = "all";
-
-        when(questRepository.findQuestsByMemberEmail(eq(testEmail), eq(offset), eq(size))).thenReturn(mockQuests);
-
-        // when
-        List<QuestsResponseDto> result = questService.findQuestsByMemberEmail(testEmail, difficulty, page, size);
-
-        // then
-        assertNotNull(result);
-        assertEquals(mockQuests.size(), result.size());
-        assertEquals("title1", result.get(0).getQuestTitle());
-        assertEquals("url2", result.get(1).getAttractionImage());
-        assertEquals("addr2", result.get(1).getAttractionAddress());
-        verify(questRepository, times(1)).findQuestsByMemberEmail(testEmail, offset, size);
-    }
-
-    @Test
-    @DisplayName("특정 회원이 실행 가능한 퀘스트 목록 조회 - null 난이도")
-    void findQuestsByMemberEmail_WithNullDifficulty_ReturnsQuestList() {
-        // given
-        String testEmail = "test@example.com";
-
-        int page = 1;
-        int size = 5;
-        int offset = (page - 1) * size;
-
-        when(questRepository.findQuestsByMemberEmail(eq(testEmail), eq(offset), eq(size))).thenReturn(mockQuests);
-
-        // when
-        List<QuestsResponseDto> result = questService.findQuestsByMemberEmail(testEmail, null, page, size);
-
-        // then
-        assertNotNull(result);
-        assertEquals(mockQuests.size(), result.size());
-        verify(questRepository, times(1)).findQuestsByMemberEmail(testEmail, offset, size);
-        verify(questRepository, never()).findQuestsByMemberEmailAndDifficulty(any(), any(), anyInt(), anyInt());
-    }
-
-    @Test
-    @DisplayName("특정 회원이 실행 가능한 퀘스트 목록 조회 - 특정 난이도")
-    void findQuestsByMemberEmail_WithSpecificDifficulty_ReturnsQuestList() {
-        // given
-        String testEmail = "test@example.com";
-        int page = 1;
-        int size = 5;
-        int offset = (page - 1) * size;
-        String difficulty = "EASY";
-
-        when(questRepository.findQuestsByMemberEmailAndDifficulty(eq(testEmail), eq(difficulty), eq(offset), eq(size)))
-                .thenReturn(mockQuests);
-
-        // when
-        List<QuestsResponseDto> result = questService.findQuestsByMemberEmail(testEmail, difficulty, page, size);
-
-        // then
-        assertNotNull(result);
-        assertEquals(mockQuests.size(), result.size());
-        verify(questRepository, times(1)).findQuestsByMemberEmailAndDifficulty(testEmail, difficulty, offset, size);
-        verify(questRepository, never()).findQuestsByMemberEmail(any(), anyInt(), anyInt());
-    }
-
-    @Test
-    @DisplayName("특정 회원의 퀘스트 목록이 비어있을 경우 예외 발생")
-    void findQuestsByMemberEmail_ThrowsException_WhenQuestListEmpty() {
-        // given
-        String testEmail = "test@example.com";
-
-        int page = 1;
-        int size = 10;
-        int offset = (page - 1) * size;
-        String difficulty = "all";
-
-        when(questRepository.findQuestsByMemberEmail(eq(testEmail), eq(offset), eq(size))).thenReturn(new ArrayList<>());
-
-        // when & then
-        CustomException exception = assertThrows(CustomException.class, () -> {
-            questService.findQuestsByMemberEmail(testEmail, difficulty, page, size);
-        });
-
-        assertEquals(ErrorCode.QUEST_LIST_EMPTY, exception.getErrorCode());
-        verify(questRepository, times(1)).findQuestsByMemberEmail(testEmail, offset, size);
-    }
-
-    @Test
-    @DisplayName("특정 회원의 퀘스트 목록이 비어있을 경우 예외 발생 - 특정 난이도")
-    void getTotalQuestsByMemberEmail_WithDifficulty_ReturnsTotalCount() {
-        // given
-        String testEmail = "test@example.com";
-        String difficulty = "EASY";
-        int expectedTotal = 5;
-
-        when(questRepository.getTotalQuestsByMemberEmailAndDifficulty(testEmail, difficulty)).thenReturn(expectedTotal);
-
-        // when
-        int result = questService.getTotalQuestsByMemberEmail(testEmail, difficulty);
-
-        // then
-        assertEquals(expectedTotal, result);
-        verify(questRepository, times(1)).getTotalQuestsByMemberEmailAndDifficulty(testEmail, difficulty);
-        verify(questRepository, never()).getTotalQuestsByMemberEmail(any());
-    }
-
-    @Test
-    @DisplayName("특정 회원이 실행 가능한 퀘스트 수 반환")
-    void getTotalQuestsByMemberEmail_ReturnsTotalCount() {
-        String difficulty = "all";
-
-        // given
-        String testEmail = "test@example.com";
-
-        int expectedTotal = 8;
-        when(questRepository.getTotalQuestsByMemberEmail(testEmail)).thenReturn(expectedTotal);
-
-        // when
-        int result = questService.getTotalQuestsByMemberEmail(testEmail, difficulty);
-
-        // then
-        assertEquals(expectedTotal, result);
-        verify(questRepository, times(1)).getTotalQuestsByMemberEmail(testEmail);
-    }
-
-    @Test
-    @DisplayName("유효한 관광지 ID에 대한 퀘스트 생성")
-    void saveQuest_success() {
-        // given
-        QuestRequestDto validQuestRequestDto = QuestRequestDto.builder()
-                .attractionId(56644)
-                .title("테스트 퀘스트")
-                .questDescription("테스트 퀘스트 설명입니다.")
-                .difficulty("MEDIUM")
-                .isPrivate(false)
-                .stampDescription("테스트 스탬프 설명")
-                .build();
-        String memberEmail = "test@ssafy.com";
-
-        when(questRepository.getAttractionById(validQuestRequestDto.getAttractionId())).thenReturn(1);
-        when(questRepository.getContentTypeIdByAttractionId(validQuestRequestDto.getAttractionId())).thenReturn(13);
-
-        // when
-        assertDoesNotThrow(() -> questService.saveQuest(validQuestRequestDto, memberEmail));
-
-        // then
-        verify(questRepository).saveQuest(validQuestRequestDto, memberEmail, 13);
-    }
-
-    @Test
-    @DisplayName("유효하지 않은 관광지 ID에 대한 퀘스트 생성")
-    void saveQuest_ThrowsException() {
-        // given
-        QuestRequestDto inValidQuestRequestDto = QuestRequestDto.builder()
-                .attractionId(1)
-                .title("테스트 퀘스트")
-                .questDescription("테스트 퀘스트 설명입니다.")
-                .difficulty("MEDIUM")
-                .isPrivate(false)
-                .stampDescription("테스트 스탬프 설명")
-                .build();
-        String memberEmail = "test@ssafy.com";
-
-        when(questRepository.getAttractionById(inValidQuestRequestDto.getAttractionId())).thenReturn(0);
-
-        // when & then
-        CustomException thrown = assertThrows(CustomException.class, () ->
-                questService.saveQuest(inValidQuestRequestDto, memberEmail));
-
-        assertEquals(ErrorCode.ATTRACTION_NOT_FOUND, thrown.getErrorCode());
-
-        verify(questRepository, never()).saveQuest(any(), any(), anyInt());
-    }
-
-    @Test
-    @DisplayName("퀘스트 수정")
-    void modifyQuest_Success() {
-        QuestRequestDto validQuestRequestDto = QuestRequestDto.builder()
-                .attractionId(56644)
-                .title("테스트 퀘스트")
-                .questDescription("테스트 퀘스트 설명입니다.")
-                .difficulty("MEDIUM")
-                .isPrivate(false)
-                .stampDescription("테스트 스탬프 설명")
-                .build();
-        int questId = 1;
-        String memberEmail = "test@ssafy.com";
-
-        // given
-        when(questRepository.getAttractionById(validQuestRequestDto.getAttractionId())).thenReturn(1);
-        when(questRepository.getmemberEmailByQuestId(questId)).thenReturn(memberEmail);
-
-        // when
-        questService.modifyQuest(questId, validQuestRequestDto, memberEmail);
-
-        // then
-        verify(questRepository, times(1)).modifyQuest(questId, validQuestRequestDto);
-    }
-
-    @Test
-    @DisplayName("유효하지 않은 관광지 ID에 대한 퀘스트 생성")
-    void modifyQuest_WithInvalidAttractionId_ThrowsException() {
-        QuestRequestDto inValidQuestRequestDto = QuestRequestDto.builder()
-                .attractionId(1)
-                .title("테스트 퀘스트")
-                .questDescription("테스트 퀘스트 설명입니다.")
-                .difficulty("MEDIUM")
-                .isPrivate(false)
-                .stampDescription("테스트 스탬프 설명")
-                .build();
-        String memberEmail = "test@ssafy.com";
-        int questId = 1;
-
-        // given
-        when(questRepository.getAttractionById(inValidQuestRequestDto.getAttractionId())).thenReturn(0);
-
-        // when & then
-        CustomException exception = assertThrows(CustomException.class, () -> {
-            questService.modifyQuest(questId, inValidQuestRequestDto, memberEmail);
-        });
-
-        assertEquals(ErrorCode.ATTRACTION_NOT_FOUND, exception.getErrorCode());
-        verify(questRepository, never()).modifyQuest(anyInt(), any(QuestRequestDto.class));
-    }
-
-    @Test
-    @DisplayName("권한 없는 회원이 퀘스트 수정")
-    void modifyQuest_WithUnauthorizedMember_ThrowsException() {
-        QuestRequestDto validQuestRequestDto = QuestRequestDto.builder()
-                .attractionId(56644)
-                .title("테스트 퀘스트")
-                .questDescription("테스트 퀘스트 설명입니다.")
-                .difficulty("MEDIUM")
-                .isPrivate(false)
-                .stampDescription("테스트 스탬프 설명")
-                .build();
-        int questId = 1;
-        String memberEmail = "test@ssafy.com";
-
-        // given
-        when(questRepository.getAttractionById(validQuestRequestDto.getAttractionId())).thenReturn(1);
-        when(questRepository.getmemberEmailByQuestId(questId)).thenReturn("another@ssafy.com");
-
-        // when & then
-        CustomException exception = assertThrows(CustomException.class, () -> {
-            questService.modifyQuest(questId, validQuestRequestDto, memberEmail);
-        });
-
-        assertEquals(ErrorCode.UNAUTHORIZED_MEMBER, exception.getErrorCode());
-        verify(questRepository, never()).modifyQuest(anyInt(), any(QuestRequestDto.class));
-    }
-
-    @Test
-    @DisplayName("퀘스트 삭제 성공")
-    void deleteQuest_Success() {
-        int questId = 1;
-        String memberEmail = "test@ssafy.com";
-
-        // given
-        when(questRepository.getQuestCntByQuestId(questId)).thenReturn(1);
-        when(questRepository.getmemberEmailByQuestId(questId)).thenReturn(memberEmail);
-        when(questRepository.getValidQuestCntByQuestId(questId)).thenReturn(1);
-
-        // when
-        questService.deleteQuest(questId, memberEmail);
-
-        // then
-        verify(questRepository, times(1)).deleteQuest(questId);
-    }
-
-    @Test
-    @DisplayName("존재하지 않는 퀘스트 삭제")
-    void deleteQuest_QuestNotFound_ThrowsException() {
-        int questId = 1;
-        String memberEmail = "test@ssafy.com";
-
-        // given
-        when(questRepository.getQuestCntByQuestId(questId)).thenReturn(0);
-
-        // when & then
-        CustomException exception = assertThrows(CustomException.class, () -> {
-            questService.deleteQuest(questId, memberEmail);
-        });
-
-        assertEquals(ErrorCode.QUEST_NOT_FOUND, exception.getErrorCode());
-        verify(questRepository, never()).deleteQuest(anyInt());
-    }
-
-    @Test
-    @DisplayName("권한 없는 회원이 퀘스트 삭제")
-    void deleteQuest_UnauthorizedMember_ThrowsException() {
-        int questId = 1;
-        String memberEmail = "test@ssafy.com";
-
-        // given
-        when(questRepository.getQuestCntByQuestId(questId)).thenReturn(1);
-        when(questRepository.getmemberEmailByQuestId(questId)).thenReturn("another@ssafy.com");
-
-        // when & then
-        CustomException exception = assertThrows(CustomException.class, () -> {
-            questService.deleteQuest(questId, memberEmail);
-        });
-
-        assertEquals(ErrorCode.UNAUTHORIZED_MEMBER, exception.getErrorCode());
-        verify(questRepository, never()).deleteQuest(anyInt());
-    }
-
-    @Test
-    @DisplayName("이미 삭제된 퀘스트 삭제 시 예외 발생 테스트")
-    void deleteQuest_AlreadyDeleted_ThrowsException() {
-        int questId = 1;
-        String memberEmail = "test@ssafy.com";
-
-        // given
-        when(questRepository.getQuestCntByQuestId(questId)).thenReturn(1);
-        when(questRepository.getmemberEmailByQuestId(questId)).thenReturn(memberEmail);
-        when(questRepository.getValidQuestCntByQuestId(questId)).thenReturn(0);
-
-        // when & then
-        CustomException exception = assertThrows(CustomException.class, () -> {
-            questService.deleteQuest(questId, memberEmail);
-        });
-
-        assertEquals(ErrorCode.QUEST_ALREADY_DELETED, exception.getErrorCode());
-        verify(questRepository, never()).deleteQuest(anyInt());
-    }
-}
+//package com.ssafy.questory.service;
+//
+//import com.ssafy.questory.common.exception.CustomException;
+//import com.ssafy.questory.common.exception.ErrorCode;
+//import com.ssafy.questory.dto.request.quest.QuestRequestDto;
+//import com.ssafy.questory.dto.response.quest.QuestsResponseDto;
+//import com.ssafy.questory.repository.QuestRepository;
+//import org.junit.jupiter.api.BeforeEach;
+//import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.api.Test;
+//
+//import java.util.ArrayList;
+//import java.util.Arrays;
+//import java.util.List;
+//
+//import static org.junit.jupiter.api.Assertions.*;
+//import static org.mockito.Mockito.*;
+//
+//class QuestServiceTest {
+//
+//    private QuestRepository questRepository = mock(QuestRepository.class);
+//    private QuestService questService;
+//
+//    private List<QuestsResponseDto> mockQuests;
+//
+//    @BeforeEach
+//    void setUp() {
+//        questService = new QuestService(questRepository);
+//
+//        QuestsResponseDto quest1 = QuestsResponseDto.builder()
+//                .questTitle("title1")
+//                .attractionImage("url1")
+//                .attractionTitle("name1")
+//                .contentTypeName("contentType1")
+//                .attractionAddress("addr1")
+//                .questDifficulty("EASY")
+//                .questDescription("description1")
+//                .build();
+//
+//        QuestsResponseDto quest2 = QuestsResponseDto.builder()
+//                .questTitle("title2")
+//                .attractionImage("url2")
+//                .attractionTitle("name2")
+//                .contentTypeName("contentType2")
+//                .attractionAddress("addr2")
+//                .questDifficulty("EASY")
+//                .questDescription("description2")
+//                .build();
+//        mockQuests = Arrays.asList(quest1, quest2);
+//    }
+//
+//    @Test
+//    @DisplayName("전체 퀘스트 목록 조회 성공")
+//    void findQuests_ReturnsQuestList() {
+//        // given
+//        int page = 1;
+//        int size = 5;
+//        int offset = (page - 1) * size;
+//
+//        when(questRepository.findQuests(offset, size)).thenReturn(mockQuests);
+//
+//        // when
+//        List<QuestsResponseDto> result = questService.findQuests(page, size);
+//
+//        // then
+//        assertNotNull(result);
+//        assertEquals(mockQuests.size(), result.size());
+//        verify(questRepository, times(1)).findQuests(offset, size);
+//    }
+//
+//    @Test
+//    @DisplayName("퀘스트 목록이 비어있을 경우 예외 발생")
+//    void findQuests_ThrowsException_WhenQuestListEmpty() {
+//        // given
+//        int page = 1;
+//        int size = 10;
+//        int offset = (page - 1) * size;
+//
+//        when(questRepository.findQuests(offset, size)).thenReturn(new ArrayList<>());
+//
+//        // when & then
+//        CustomException exception = assertThrows(CustomException.class, () -> {
+//            questService.findQuests(page, size);
+//        });
+//
+//        assertEquals(ErrorCode.QUEST_LIST_EMPTY, exception.getErrorCode());
+//        verify(questRepository, times(1)).findQuests(offset, size);
+//    }
+//
+//    @Test
+//    @DisplayName("전체 퀘스트 수 반환")
+//    void getTotalQuests_ReturnsTotalCount() {
+//        // given
+//        int expectedTotal = 15;
+//        when(questRepository.getTotalQuests()).thenReturn(expectedTotal);
+//
+//        // when
+//        int result = questService.getTotalQuests();
+//
+//        // then
+//        assertEquals(expectedTotal, result);
+//        verify(questRepository, times(1)).getTotalQuests();
+//    }
+//
+//    @Test
+//    @DisplayName("특정 회원이 실행 가능한 퀘스트 목록 조회 - 전체 난이도")
+//    void findValidQuestsByMemberEmail_ReturnsQuestList() {
+//        // given
+//        String testEmail = "test@example.com";
+//
+//        int page = 1;
+//        int size = 5;
+//        int offset = (page - 1) * size;
+//        String difficulty = "all";
+//
+//        when(questRepository.findQuestsByMemberEmail(eq(testEmail), eq(offset), eq(size))).thenReturn(mockQuests);
+//
+//        // when
+//        List<QuestsResponseDto> result = questService.findValidQuestsByMemberEmail(testEmail, difficulty, page, size);
+//
+//        // then
+//        assertNotNull(result);
+//        assertEquals(mockQuests.size(), result.size());
+//        assertEquals("title1", result.get(0).getQuestTitle());
+//        assertEquals("url2", result.get(1).getAttractionImage());
+//        assertEquals("addr2", result.get(1).getAttractionAddress());
+//        verify(questRepository, times(1)).findQuestsByMemberEmail(testEmail, offset, size);
+//    }
+//
+//    @Test
+//    @DisplayName("특정 회원이 실행 가능한 퀘스트 목록 조회 - null 난이도")
+//    void findValidQuestsByMemberEmail_WithNullDifficulty_ReturnsQuestList() {
+//        // given
+//        String testEmail = "test@example.com";
+//
+//        int page = 1;
+//        int size = 5;
+//        int offset = (page - 1) * size;
+//
+//        when(questRepository.findQuestsByMemberEmail(eq(testEmail), eq(offset), eq(size))).thenReturn(mockQuests);
+//
+//        // when
+//        List<QuestsResponseDto> result = questService.findValidQuestsByMemberEmail(testEmail, null, page, size);
+//
+//        // then
+//        assertNotNull(result);
+//        assertEquals(mockQuests.size(), result.size());
+//        verify(questRepository, times(1)).findQuestsByMemberEmail(testEmail, offset, size);
+//        verify(questRepository, never()).findQuestsByMemberEmailAndDifficulty(any(), any(), anyInt(), anyInt());
+//    }
+//
+//    @Test
+//    @DisplayName("특정 회원이 실행 가능한 퀘스트 목록 조회 - 특정 난이도")
+//    void findValidQuestsByMemberEmail_WithSpecificDifficulty_ReturnsQuestList() {
+//        // given
+//        String testEmail = "test@example.com";
+//        int page = 1;
+//        int size = 5;
+//        int offset = (page - 1) * size;
+//        String difficulty = "EASY";
+//
+//        when(questRepository.findQuestsByMemberEmailAndDifficulty(eq(testEmail), eq(difficulty), eq(offset), eq(size)))
+//                .thenReturn(mockQuests);
+//
+//        // when
+//        List<QuestsResponseDto> result = questService.findValidQuestsByMemberEmail(testEmail, difficulty, page, size);
+//
+//        // then
+//        assertNotNull(result);
+//        assertEquals(mockQuests.size(), result.size());
+//        verify(questRepository, times(1)).findQuestsByMemberEmailAndDifficulty(testEmail, difficulty, offset, size);
+//        verify(questRepository, never()).findQuestsByMemberEmail(any(), anyInt(), anyInt());
+//    }
+//
+//    @Test
+//    @DisplayName("특정 회원의 퀘스트 목록이 비어있을 경우 예외 발생")
+//    void findValidQuestsByMemberEmail_ThrowsException_WhenQuestListEmpty() {
+//        // given
+//        String testEmail = "test@example.com";
+//
+//        int page = 1;
+//        int size = 10;
+//        int offset = (page - 1) * size;
+//        String difficulty = "all";
+//
+//        when(questRepository.findQuestsByMemberEmail(eq(testEmail), eq(offset), eq(size))).thenReturn(new ArrayList<>());
+//
+//        // when & then
+//        CustomException exception = assertThrows(CustomException.class, () -> {
+//            questService.findValidQuestsByMemberEmail(testEmail, difficulty, page, size);
+//        });
+//
+//        assertEquals(ErrorCode.QUEST_LIST_EMPTY, exception.getErrorCode());
+//        verify(questRepository, times(1)).findQuestsByMemberEmail(testEmail, offset, size);
+//    }
+//
+//    @Test
+//    @DisplayName("특정 회원의 퀘스트 목록이 비어있을 경우 예외 발생 - 특정 난이도")
+//    void getTotalQuestsByMemberEmail_WithDifficulty_ReturnsTotalCount() {
+//        // given
+//        String testEmail = "test@example.com";
+//        String difficulty = "EASY";
+//        int expectedTotal = 5;
+//
+//        when(questRepository.getTotalQuestsByMemberEmailAndDifficulty(testEmail, difficulty)).thenReturn(expectedTotal);
+//
+//        // when
+//        int result = questService.getTotalQuestsByMemberEmail(testEmail, difficulty);
+//
+//        // then
+//        assertEquals(expectedTotal, result);
+//        verify(questRepository, times(1)).getTotalQuestsByMemberEmailAndDifficulty(testEmail, difficulty);
+//        verify(questRepository, never()).getTotalQuestsByMemberEmail(any());
+//    }
+//
+//    @Test
+//    @DisplayName("특정 회원이 실행 가능한 퀘스트 수 반환")
+//    void getTotalQuestsByMemberEmail_ReturnsTotalCount() {
+//        String difficulty = "all";
+//
+//        // given
+//        String testEmail = "test@example.com";
+//
+//        int expectedTotal = 8;
+//        when(questRepository.getTotalQuestsByMemberEmail(testEmail)).thenReturn(expectedTotal);
+//
+//        // when
+//        int result = questService.getTotalQuestsByMemberEmail(testEmail, difficulty);
+//
+//        // then
+//        assertEquals(expectedTotal, result);
+//        verify(questRepository, times(1)).getTotalQuestsByMemberEmail(testEmail);
+//    }
+//
+//    @Test
+//    @DisplayName("유효한 관광지 ID에 대한 퀘스트 생성")
+//    void saveQuest_success() {
+//        // given
+//        QuestRequestDto validQuestRequestDto = QuestRequestDto.builder()
+//                .attractionId(56644)
+//                .title("테스트 퀘스트")
+//                .questDescription("테스트 퀘스트 설명입니다.")
+//                .difficulty("MEDIUM")
+//                .isPrivate(false)
+//                .stampDescription("테스트 스탬프 설명")
+//                .build();
+//        String memberEmail = "test@ssafy.com";
+//
+//        when(questRepository.getAttractionById(validQuestRequestDto.getAttractionId())).thenReturn(1);
+//        when(questRepository.getContentTypeIdByAttractionId(validQuestRequestDto.getAttractionId())).thenReturn(13);
+//
+//        // when
+//        assertDoesNotThrow(() -> questService.saveQuest(validQuestRequestDto, memberEmail));
+//
+//        // then
+//        verify(questRepository).saveQuest(validQuestRequestDto, memberEmail, 13);
+//    }
+//
+//    @Test
+//    @DisplayName("유효하지 않은 관광지 ID에 대한 퀘스트 생성")
+//    void saveQuest_ThrowsException() {
+//        // given
+//        QuestRequestDto inValidQuestRequestDto = QuestRequestDto.builder()
+//                .attractionId(1)
+//                .title("테스트 퀘스트")
+//                .questDescription("테스트 퀘스트 설명입니다.")
+//                .difficulty("MEDIUM")
+//                .isPrivate(false)
+//                .stampDescription("테스트 스탬프 설명")
+//                .build();
+//        String memberEmail = "test@ssafy.com";
+//
+//        when(questRepository.getAttractionById(inValidQuestRequestDto.getAttractionId())).thenReturn(0);
+//
+//        // when & then
+//        CustomException thrown = assertThrows(CustomException.class, () ->
+//                questService.saveQuest(inValidQuestRequestDto, memberEmail));
+//
+//        assertEquals(ErrorCode.ATTRACTION_NOT_FOUND, thrown.getErrorCode());
+//
+//        verify(questRepository, never()).saveQuest(any(), any(), anyInt());
+//    }
+//
+//    @Test
+//    @DisplayName("퀘스트 수정")
+//    void modifyQuest_Success() {
+//        QuestRequestDto validQuestRequestDto = QuestRequestDto.builder()
+//                .attractionId(56644)
+//                .title("테스트 퀘스트")
+//                .questDescription("테스트 퀘스트 설명입니다.")
+//                .difficulty("MEDIUM")
+//                .isPrivate(false)
+//                .stampDescription("테스트 스탬프 설명")
+//                .build();
+//        int questId = 1;
+//        String memberEmail = "test@ssafy.com";
+//
+//        // given
+//        when(questRepository.getAttractionById(validQuestRequestDto.getAttractionId())).thenReturn(1);
+//        when(questRepository.getmemberEmailByQuestId(questId)).thenReturn(memberEmail);
+//
+//        // when
+//        questService.modifyQuest(questId, validQuestRequestDto, memberEmail);
+//
+//        // then
+//        verify(questRepository, times(1)).modifyQuest(questId, validQuestRequestDto);
+//    }
+//
+//    @Test
+//    @DisplayName("유효하지 않은 관광지 ID에 대한 퀘스트 생성")
+//    void modifyQuest_WithInvalidAttractionId_ThrowsException() {
+//        QuestRequestDto inValidQuestRequestDto = QuestRequestDto.builder()
+//                .attractionId(1)
+//                .title("테스트 퀘스트")
+//                .questDescription("테스트 퀘스트 설명입니다.")
+//                .difficulty("MEDIUM")
+//                .isPrivate(false)
+//                .stampDescription("테스트 스탬프 설명")
+//                .build();
+//        String memberEmail = "test@ssafy.com";
+//        int questId = 1;
+//
+//        // given
+//        when(questRepository.getAttractionById(inValidQuestRequestDto.getAttractionId())).thenReturn(0);
+//
+//        // when & then
+//        CustomException exception = assertThrows(CustomException.class, () -> {
+//            questService.modifyQuest(questId, inValidQuestRequestDto, memberEmail);
+//        });
+//
+//        assertEquals(ErrorCode.ATTRACTION_NOT_FOUND, exception.getErrorCode());
+//        verify(questRepository, never()).modifyQuest(anyInt(), any(QuestRequestDto.class));
+//    }
+//
+//    @Test
+//    @DisplayName("권한 없는 회원이 퀘스트 수정")
+//    void modifyQuest_WithUnauthorizedMember_ThrowsException() {
+//        QuestRequestDto validQuestRequestDto = QuestRequestDto.builder()
+//                .attractionId(56644)
+//                .title("테스트 퀘스트")
+//                .questDescription("테스트 퀘스트 설명입니다.")
+//                .difficulty("MEDIUM")
+//                .isPrivate(false)
+//                .stampDescription("테스트 스탬프 설명")
+//                .build();
+//        int questId = 1;
+//        String memberEmail = "test@ssafy.com";
+//
+//        // given
+//        when(questRepository.getAttractionById(validQuestRequestDto.getAttractionId())).thenReturn(1);
+//        when(questRepository.getmemberEmailByQuestId(questId)).thenReturn("another@ssafy.com");
+//
+//        // when & then
+//        CustomException exception = assertThrows(CustomException.class, () -> {
+//            questService.modifyQuest(questId, validQuestRequestDto, memberEmail);
+//        });
+//
+//        assertEquals(ErrorCode.UNAUTHORIZED_MEMBER, exception.getErrorCode());
+//        verify(questRepository, never()).modifyQuest(anyInt(), any(QuestRequestDto.class));
+//    }
+//
+//    @Test
+//    @DisplayName("퀘스트 삭제 성공")
+//    void deleteQuest_Success() {
+//        int questId = 1;
+//        String memberEmail = "test@ssafy.com";
+//
+//        // given
+//        when(questRepository.getQuestCntByQuestId(questId)).thenReturn(1);
+//        when(questRepository.getmemberEmailByQuestId(questId)).thenReturn(memberEmail);
+//        when(questRepository.getValidQuestCntByQuestId(questId)).thenReturn(1);
+//
+//        // when
+//        questService.deleteQuest(questId, memberEmail);
+//
+//        // then
+//        verify(questRepository, times(1)).deleteQuest(questId);
+//    }
+//
+//    @Test
+//    @DisplayName("존재하지 않는 퀘스트 삭제")
+//    void deleteQuest_QuestNotFound_ThrowsException() {
+//        int questId = 1;
+//        String memberEmail = "test@ssafy.com";
+//
+//        // given
+//        when(questRepository.getQuestCntByQuestId(questId)).thenReturn(0);
+//
+//        // when & then
+//        CustomException exception = assertThrows(CustomException.class, () -> {
+//            questService.deleteQuest(questId, memberEmail);
+//        });
+//
+//        assertEquals(ErrorCode.QUEST_NOT_FOUND, exception.getErrorCode());
+//        verify(questRepository, never()).deleteQuest(anyInt());
+//    }
+//
+//    @Test
+//    @DisplayName("권한 없는 회원이 퀘스트 삭제")
+//    void deleteQuest_UnauthorizedMember_ThrowsException() {
+//        int questId = 1;
+//        String memberEmail = "test@ssafy.com";
+//
+//        // given
+//        when(questRepository.getQuestCntByQuestId(questId)).thenReturn(1);
+//        when(questRepository.getmemberEmailByQuestId(questId)).thenReturn("another@ssafy.com");
+//
+//        // when & then
+//        CustomException exception = assertThrows(CustomException.class, () -> {
+//            questService.deleteQuest(questId, memberEmail);
+//        });
+//
+//        assertEquals(ErrorCode.UNAUTHORIZED_MEMBER, exception.getErrorCode());
+//        verify(questRepository, never()).deleteQuest(anyInt());
+//    }
+//
+//    @Test
+//    @DisplayName("이미 삭제된 퀘스트 삭제 시 예외 발생 테스트")
+//    void deleteQuest_AlreadyDeleted_ThrowsException() {
+//        int questId = 1;
+//        String memberEmail = "test@ssafy.com";
+//
+//        // given
+//        when(questRepository.getQuestCntByQuestId(questId)).thenReturn(1);
+//        when(questRepository.getmemberEmailByQuestId(questId)).thenReturn(memberEmail);
+//        when(questRepository.getValidQuestCntByQuestId(questId)).thenReturn(0);
+//
+//        // when & then
+//        CustomException exception = assertThrows(CustomException.class, () -> {
+//            questService.deleteQuest(questId, memberEmail);
+//        });
+//
+//        assertEquals(ErrorCode.QUEST_ALREADY_DELETED, exception.getErrorCode());
+//        verify(questRepository, never()).deleteQuest(anyInt());
+//    }
+//}


### PR DESCRIPTION
# 관련 이슈
- resolves: #48


# 작업 내용
- 생성한 퀘스트 리스트 조회 기능 구현
- QuestsResponseDto 구조 변경
- @toString 추가 