### PR TITLE
[FEAT] #53 - 퀘스트 진행 취소 기능 구현

### DIFF
--- a/src/main/java/com/ssafy/questory/controller/QuestController.java
+++ b/src/main/java/com/ssafy/questory/controller/QuestController.java
@@ -183,4 +183,17 @@ public class QuestController {
         return ResponseEntity.status(HttpStatus.OK).body(Map.of(
                 "message", "성공적으로 퀘스트를 삭제했습니다."));
     }
+
+    @PatchMapping("/{questId}/cancel")
+    @Operation(summary = "퀘스트 진행 취소", description = "퀘스트 진행을 취소합니다.")
+    public ResponseEntity<Map<String, String>> cancelQuest(@PathVariable int questId,
+                                                           @RequestHeader("Authorization") String authorizationHeader){
+        String token = authorizationHeader.substring(7);
+        String memberEmail = jwtService.extractUsername(token);
+
+        questService.cancelQuest(questId, memberEmail);
+
+        return ResponseEntity.status(HttpStatus.OK).body(Map.of(
+                "message", "성공적으로 퀘스트를 취소했습니다."));
+    }
 }

--- a/src/main/java/com/ssafy/questory/controller/QuestController.java
+++ b/src/main/java/com/ssafy/questory/controller/QuestController.java
@@ -78,7 +78,7 @@ public class QuestController {
 
         List<QuestsResponseDto> questsResponseDtoList = questService.findQuestsCreatedByMe(memberEmail, difficulty, page, size);
 
-        int totalItems = questService.getTotalQuestsByMemberEmail(memberEmail, difficulty);
+        int totalItems = questService.getQuestsCntCreatedByMe(memberEmail, difficulty);
         int totalPages = (int) Math.ceil((double) totalItems / size);
 
         Map<String, Object> pagination = new HashMap<>();

--- a/src/main/java/com/ssafy/questory/repository/QuestRepository.java
+++ b/src/main/java/com/ssafy/questory/repository/QuestRepository.java
@@ -59,4 +59,6 @@ public interface QuestRepository {
     int getActiveQuestsByMemberEmail(@Param("memberEmail") String memberEmail);
 
     int getActiveQuestsByMemberEmailAndDifficulty(@Param("memberEmail") String memberEmail, @Param("difficulty") String difficulty);
+
+    void cancelQuest(@Param("questId") int questId);
 }

--- a/src/main/java/com/ssafy/questory/service/QuestService.java
+++ b/src/main/java/com/ssafy/questory/service/QuestService.java
@@ -153,4 +153,12 @@ public class QuestService {
             return questRepository.getActiveQuestsByMemberEmailAndDifficulty(memberEmail, difficulty);
         }
     }
+
+    public void cancelQuest(int questId, String memberEmail) {
+        int questCntByQuestId = questRepository.getQuestCntByQuestId(questId);
+        if(questCntByQuestId!=1){
+            throw new CustomException(ErrorCode.QUEST_NOT_FOUND);
+        }
+        questRepository.cancelQuest(questId);
+    }
 }

--- a/src/main/java/com/ssafy/questory/service/QuestService.java
+++ b/src/main/java/com/ssafy/questory/service/QuestService.java
@@ -71,7 +71,7 @@ public class QuestService {
         return questsResponseDtoList;
     }
 
-    public int findQuestsCreatedByMe(String memberEmail, String difficulty) {
+    public int getQuestsCntCreatedByMe(String memberEmail, String difficulty) {
         if(difficulty== null || difficulty.equals("all")){
             return questRepository.getTotalQuestsCreatedByMe(memberEmail);
         }else{

--- a/src/main/resources/mappers/Quest.xml
+++ b/src/main/resources/mappers/Quest.xml
@@ -50,7 +50,7 @@
         JOIN
         contenttypes ct ON a.content_type_id = ct.content_type_id
         WHERE
-        (mq.is_completed = 'YET' OR mq.is_completed IS NULL) AND  q.is_deleted = 0 AND q.is_private = 0
+        (mq.is_completed = 'READY' OR mq.is_completed IS NULL) AND  q.is_deleted = 0 AND q.is_private = 0
         LIMIT #{offset}, #{limit};
     </select>
 
@@ -63,7 +63,7 @@
             (select * from members_quests where member_email = #{memberEmail}) mq
             ON q.location_quest_id = mq.location_quest_id
         WHERE
-            (mq.is_completed = 'YET' OR mq.is_completed IS NULL) AND  q.is_deleted = 0 AND q.is_private = 0;
+            (mq.is_completed = 'READY' OR mq.is_completed IS NULL) AND  q.is_deleted = 0 AND q.is_private = 0;
     </select>
 
     <select id="findQuestsByMemberEmailAndDifficulty" resultMap="questsMap" resultType="com.ssafy.questory.dto.response.quest.QuestsResponseDto">
@@ -86,7 +86,7 @@
         JOIN
         contenttypes ct ON a.content_type_id = ct.content_type_id
         WHERE
-        (mq.is_completed = 'YET' OR mq.is_completed IS NULL) AND  q.is_deleted = 0 AND q.is_private = 0 AND q.difficulty=#{difficulty}
+        (mq.is_completed = 'READY' OR mq.is_completed IS NULL) AND  q.is_deleted = 0 AND q.is_private = 0 AND q.difficulty=#{difficulty}
         LIMIT #{offset}, #{limit};
     </select>
 
@@ -99,7 +99,7 @@
             (select * from members_quests where member_email = #{memberEmail}) mq
             ON q.location_quest_id = mq.location_quest_id
         WHERE
-            (mq.is_completed = 'YET' OR mq.is_completed IS NULL) AND  q.is_deleted = 0 AND q.is_private = 0 AND difficulty=#{difficulty};
+            (mq.is_completed = 'READY' OR mq.is_completed IS NULL) AND  q.is_deleted = 0 AND q.is_private = 0 AND difficulty=#{difficulty};
     </select>
 
     <select id="findQuestsCreatedByMe" resultMap="questsMap">
@@ -177,7 +177,7 @@
         ON q.attraction_id = a.no
         JOIN contenttypes ct
         ON a.content_type_id = ct.content_type_id
-        where mq.is_completed = 'YET' AND mq.member_email = #{memberEmail}
+        where mq.is_completed = 'IN_PROGRESS' AND mq.member_email = #{memberEmail}
         LIMIT #{offset}, #{limit};
     </select>
 
@@ -198,7 +198,7 @@
         ON q.attraction_id = a.no
         JOIN contenttypes ct
         ON a.content_type_id = ct.content_type_id
-        where mq.is_completed = 'YET' AND mq.member_email = #{memberEmail} AND q.difficulty = #{difficulty}
+        where mq.is_completed = 'IN_PROGRESS' AND mq.member_email = #{memberEmail} AND q.difficulty = #{difficulty}
         LIMIT #{offset}, #{limit};
     </select>
 
@@ -212,7 +212,7 @@
             ON q.attraction_id = a.no
         JOIN contenttypes ct
             ON a.content_type_id = ct.content_type_id
-        where mq.is_completed = 'YET' AND mq.member_email = #{memberEmail};
+        where mq.is_completed = 'IN_PROGRESS' AND mq.member_email = #{memberEmail};
     </select>
 
     <select id="getActiveQuestsByMemberEmailAndDifficulty">
@@ -224,7 +224,7 @@
             ON q.attraction_id = a.no
         JOIN contenttypes ct
             ON a.content_type_id = ct.content_type_id
-        WHERE mq.is_completed = 'YET' AND mq.member_email = #{memberEmail} AND q.difficulty = #{difficulty};
+        WHERE mq.is_completed = 'IN_PROGRESS' AND mq.member_email = #{memberEmail} AND q.difficulty = #{difficulty};
     </select>
 
     <select id="saveQuest">
@@ -324,7 +324,7 @@
         UPDATE
             Members_Quests
         SET
-            is_completed = 'CANCELLED'
+            is_completed = 'READY'
         WHERE
             location_quest_id = #{questId};
     </select>

--- a/src/main/resources/mappers/Quest.xml
+++ b/src/main/resources/mappers/Quest.xml
@@ -320,6 +320,15 @@
             location_quest_id=#{questId} AND is_deleted=0;
     </select>
 
+    <select id="cancelQuest">
+        UPDATE
+            Members_Quests
+        SET
+            is_completed = 'CANCELLED'
+        WHERE
+            location_quest_id = #{questId};
+    </select>
+
     <resultMap type="QuestsResponseDto" id="questsMap">
         <result column="location_quest_id" property="questId" />
         <result column="quest_title" property="questTitle" />

--- a/src/main/resources/mappers/Stamp.xml
+++ b/src/main/resources/mappers/Stamp.xml
@@ -27,7 +27,7 @@
         WHERE
          mq.member_email = #{memberEmail}
         AND
-            mq.is_completed='COMPLETE'
+            mq.is_completed='COMPLETED'
         ORDER BY
             mq.created_at
         LIMIT #{offset}, #{limit};
@@ -57,7 +57,7 @@
         AND
             q.difficulty = #{difficulty}
         AND
-            mq.is_completed='COMPLETE'
+            mq.is_completed='COMPLETED'
         ORDER BY
             mq.created_at
         LIMIT #{offset}, #{limit};
@@ -72,7 +72,7 @@
         WHERE
         mq.member_email = #{memberEmail}
         AND
-        mq.is_completed='COMPLETE';
+        mq.is_completed='COMPLETED';
     </select>
 
     <select id="countStampsByDifficulty" resultType="int">
@@ -84,7 +84,7 @@
         WHERE
             mq.member_email = #{memberEmail}
         AND
-            mq.is_completed='COMPLETE'
+            mq.is_completed='COMPLETED'
         AND
             q.difficulty = #{difficulty};
     </select>

--- a/src/main/resources/sql/questory.sql
+++ b/src/main/resources/sql/questory.sql
@@ -98,6 +98,6 @@ CREATE TABLE Quests (
 CREATE TABLE Members_Quests (
     member_email VARCHAR(40) NOT NULL,
     location_quest_id INT NOT NULL,
-    is_completed ENUM('READY', 'IN_PROGRESS', 'COMPLETED','CANCELLED') DEFAULT 'READY',
+    is_completed ENUM('READY', 'IN_PROGRESS', 'COMPLETED') DEFAULT 'READY',
     created_at DATETIME DEFAULT NOW()
 );

--- a/src/main/resources/sql/questory.sql
+++ b/src/main/resources/sql/questory.sql
@@ -98,6 +98,6 @@ CREATE TABLE Quests (
 CREATE TABLE Members_Quests (
     member_email VARCHAR(40) NOT NULL,
     location_quest_id INT NOT NULL,
-    is_completed ENUM('YET', 'COMPLETE','CANCELED') DEFAULT 'YET',
+    is_completed ENUM('READY', 'IN_PROGRESS', 'COMPLETED','CANCELLED') DEFAULT 'READY',
     created_at DATETIME DEFAULT NOW()
 );


### PR DESCRIPTION
# 관련 이슈
- resolves: #53 

# 작업 내용
- 퀘스트 진행 취소 기능 구현
    - 상태값 READY로 변경
- members-quests 테이블의 is_complete 상태 값 수정한 sql 업로드
    - READY, IN_PROGRESS, COMPLETED