### PR TITLE
[FEAT] #56 - 퀘스트 시작 기능, 퀘스트 완료 기능 구현

### DIFF
--- a/src/main/java/com/ssafy/questory/common/exception/ErrorCode.java
+++ b/src/main/java/com/ssafy/questory/common/exception/ErrorCode.java
@@ -38,7 +38,8 @@ public enum ErrorCode {
     QUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 퀘스트입니다."),
     QUEST_ALREADY_DELETED(HttpStatus.GONE, "이미 삭제된 퀘스트입니다."),
     QUEST_LIST_EMPTY(HttpStatus.NO_CONTENT, "조회할 퀘스트가 없습니다."),
-    QUEST_ALREADY_STARTED(HttpStatus.NO_CONTENT, "이미 진행중인 퀘스트입니다."),
+    QUEST_ALREADY_STARTED(HttpStatus.BAD_REQUEST, "이미 진행중인 퀘스트입니다."),
+    QUEST_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "이미 완료된 퀘스트입니다."),
 
     // 계획, 경로 관련
     PLAN_NOT_FOUND(HttpStatus.NOT_FOUND, "회원이 생성한 계획이 없습니다."),

--- a/src/main/java/com/ssafy/questory/common/exception/ErrorCode.java
+++ b/src/main/java/com/ssafy/questory/common/exception/ErrorCode.java
@@ -40,6 +40,7 @@ public enum ErrorCode {
     QUEST_LIST_EMPTY(HttpStatus.NO_CONTENT, "조회할 퀘스트가 없습니다."),
     QUEST_ALREADY_STARTED(HttpStatus.BAD_REQUEST, "이미 진행중인 퀘스트입니다."),
     QUEST_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "이미 완료된 퀘스트입니다."),
+    QUEST_LOCATION_TOO_FAR(HttpStatus.BAD_REQUEST, "사용자가 퀘스트 완료 가능 거리에 있지 않습니다."),
 
     // 계획, 경로 관련
     PLAN_NOT_FOUND(HttpStatus.NOT_FOUND, "회원이 생성한 계획이 없습니다."),

--- a/src/main/java/com/ssafy/questory/common/exception/ErrorCode.java
+++ b/src/main/java/com/ssafy/questory/common/exception/ErrorCode.java
@@ -38,6 +38,7 @@ public enum ErrorCode {
     QUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 퀘스트입니다."),
     QUEST_ALREADY_DELETED(HttpStatus.GONE, "이미 삭제된 퀘스트입니다."),
     QUEST_LIST_EMPTY(HttpStatus.NO_CONTENT, "조회할 퀘스트가 없습니다."),
+    QUEST_ALREADY_STARTED(HttpStatus.NO_CONTENT, "이미 진행중인 퀘스트입니다."),
 
     // 계획, 경로 관련
     PLAN_NOT_FOUND(HttpStatus.NOT_FOUND, "회원이 생성한 계획이 없습니다."),

--- a/src/main/java/com/ssafy/questory/controller/QuestController.java
+++ b/src/main/java/com/ssafy/questory/controller/QuestController.java
@@ -196,4 +196,17 @@ public class QuestController {
         return ResponseEntity.status(HttpStatus.OK).body(Map.of(
                 "message", "성공적으로 퀘스트를 취소했습니다."));
     }
+
+    @PatchMapping("/{questId}/start")
+    @Operation(summary = "퀘스트 진행 시작", description = "퀘스트 진행을 시작합니다.")
+    public ResponseEntity<Map<String, String>> startQuest(@PathVariable int questId,
+                                                           @RequestHeader("Authorization") String authorizationHeader){
+        String token = authorizationHeader.substring(7);
+        String memberEmail = jwtService.extractUsername(token);
+
+        questService.startQuest(questId, memberEmail);
+
+        return ResponseEntity.status(HttpStatus.OK).body(Map.of(
+                "message", "성공적으로 퀘스트를 시작했습니다."));
+    }
 }

--- a/src/main/java/com/ssafy/questory/controller/QuestController.java
+++ b/src/main/java/com/ssafy/questory/controller/QuestController.java
@@ -40,7 +40,7 @@ public class QuestController {
             String memberEmail = jwtService.extractUsername(token);
 
             questsResponseDtoList = questService.findValidQuestsByMemberEmail(memberEmail, difficulty, page, size);
-            totalItems = questService.getTotalQuestsByMemberEmail(memberEmail, difficulty);
+            totalItems = questService.getValidQuestsCntByMemberEmail(memberEmail, difficulty);
             totalPages = (int) Math.ceil((double) totalItems / size);
         }else{
             questsResponseDtoList = questService.findQuests(page, size);

--- a/src/main/java/com/ssafy/questory/controller/QuestController.java
+++ b/src/main/java/com/ssafy/questory/controller/QuestController.java
@@ -3,6 +3,7 @@ package com.ssafy.questory.controller;
 import com.ssafy.questory.common.exception.CustomException;
 import com.ssafy.questory.common.exception.ErrorCode;
 import com.ssafy.questory.config.jwt.JwtService;
+import com.ssafy.questory.dto.request.quest.QuestPositionRequestDto;
 import com.ssafy.questory.dto.request.quest.QuestRequestDto;
 import com.ssafy.questory.dto.response.quest.QuestResponseDto;
 import com.ssafy.questory.dto.response.quest.QuestsResponseDto;
@@ -208,5 +209,19 @@ public class QuestController {
 
         return ResponseEntity.status(HttpStatus.OK).body(Map.of(
                 "message", "성공적으로 퀘스트를 시작했습니다."));
+    }
+
+    @PatchMapping("/{questId}/complete")
+    @Operation(summary = "퀘스트 완료", description = "퀘스트를 완료하였습니다.")
+    public ResponseEntity<Map<String, String>> completeQuest(@PathVariable int questId,
+                                                          @RequestBody QuestPositionRequestDto questPositionRequestDto,
+                                                          @RequestHeader("Authorization") String authorizationHeader){
+        String token = authorizationHeader.substring(7);
+        String memberEmail = jwtService.extractUsername(token);
+
+        questService.completeQuest(questId, questPositionRequestDto, memberEmail);
+
+        return ResponseEntity.status(HttpStatus.OK).body(Map.of(
+                "message", "성공적으로 퀘스트를 완료했습니다."));
     }
 }

--- a/src/main/java/com/ssafy/questory/dto/request/quest/QuestPositionRequestDto.java
+++ b/src/main/java/com/ssafy/questory/dto/request/quest/QuestPositionRequestDto.java
@@ -1,0 +1,19 @@
+package com.ssafy.questory.dto.request.quest;
+
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class QuestPositionRequestDto {
+    private Double attractionLatitude;
+    private Double attractionLongitude;
+    private Double userLatitude;
+    private Double userLongitude;
+}

--- a/src/main/java/com/ssafy/questory/dto/response/quest/QuestsResponseDto.java
+++ b/src/main/java/com/ssafy/questory/dto/response/quest/QuestsResponseDto.java
@@ -20,4 +20,6 @@ public class QuestsResponseDto {
     private String attractionAddress;
     private String questDifficulty;
     private String questDescription;
+    private Double attractionLatitude;
+    private Double attractionLongitude;
 }

--- a/src/main/java/com/ssafy/questory/repository/QuestRepository.java
+++ b/src/main/java/com/ssafy/questory/repository/QuestRepository.java
@@ -67,4 +67,6 @@ public interface QuestRepository {
     int getMemberQuestCntByQuestId(@Param("questId") int questId, @Param("memberEmail") String memberEmail);
 
     int getInProgressQuestCntByQuestId(@Param("questId") int questId);
+
+    void completeQuest(@Param("questId") int questId, @Param("memberEmail") String memberEmail);
 }

--- a/src/main/java/com/ssafy/questory/repository/QuestRepository.java
+++ b/src/main/java/com/ssafy/questory/repository/QuestRepository.java
@@ -18,11 +18,11 @@ public interface QuestRepository {
 
     List<QuestsResponseDto> findValidQuestsByMemberEmail(@Param("memberEmail") String memberEmail, @Param("offset") int offset, @Param("limit") int limit);
 
-    int getTotalQuestsByMemberEmail(@Param("memberEmail") String memberEmail);
+    int getValidQuestsCntByMemberEmail(@Param("memberEmail") String memberEmail);
 
-    List<QuestsResponseDto> findQuestsByMemberEmailAndDifficulty(@Param("memberEmail") String memberEmail, @Param("difficulty") String difficulty, @Param("offset") int offset, @Param("limit") int limit);
+    List<QuestsResponseDto> findValidQuestsByMemberEmailAndDifficulty(@Param("memberEmail") String memberEmail, @Param("difficulty") String difficulty, @Param("offset") int offset, @Param("limit") int limit);
 
-    int getTotalQuestsByMemberEmailAndDifficulty(@Param("memberEmail") String memberEmail, @Param("difficulty") String difficulty);
+    int getValidQuestsCntByMemberEmailAndDifficulty(@Param("memberEmail") String memberEmail, @Param("difficulty") String difficulty);
 
     List<QuestsResponseDto> findQuestsCreatedByMe(@Param("memberEmail") String memberEmail, @Param("offset") int offset, @Param("limit") int limit);
 
@@ -65,4 +65,6 @@ public interface QuestRepository {
     void startQuest(@Param("questId") int questId, @Param("memberEmail") String memberEmail);
 
     int getMemberQuestCntByQuestId(@Param("questId") int questId, @Param("memberEmail") String memberEmail);
+
+    int getInProgressQuestCntByQuestId(@Param("questId") int questId);
 }

--- a/src/main/java/com/ssafy/questory/repository/QuestRepository.java
+++ b/src/main/java/com/ssafy/questory/repository/QuestRepository.java
@@ -61,4 +61,8 @@ public interface QuestRepository {
     int getActiveQuestsByMemberEmailAndDifficulty(@Param("memberEmail") String memberEmail, @Param("difficulty") String difficulty);
 
     void cancelQuest(@Param("questId") int questId);
+
+    void startQuest(@Param("questId") int questId, @Param("memberEmail") String memberEmail);
+
+    int getMemberQuestCntByQuestId(@Param("questId") int questId, @Param("memberEmail") String memberEmail);
 }

--- a/src/main/java/com/ssafy/questory/service/QuestService.java
+++ b/src/main/java/com/ssafy/questory/service/QuestService.java
@@ -39,7 +39,7 @@ public class QuestService {
         if(difficulty== null || difficulty.equals("all")){
             questsResponseDtoList = questRepository.findValidQuestsByMemberEmail(memberEmail, offset, size);
         }else{
-            questsResponseDtoList = questRepository.findQuestsByMemberEmailAndDifficulty(memberEmail, difficulty, offset, size);
+            questsResponseDtoList = questRepository.findValidQuestsByMemberEmailAndDifficulty(memberEmail, difficulty, offset, size);
         }
 
         if(questsResponseDtoList.isEmpty()){
@@ -48,11 +48,11 @@ public class QuestService {
         return questsResponseDtoList;
     }
 
-    public int getTotalQuestsByMemberEmail(String memberEmail, String difficulty) {
+    public int getValidQuestsCntByMemberEmail(String memberEmail, String difficulty) {
         if(difficulty== null || difficulty.equals("all")){
-            return questRepository.getTotalQuestsByMemberEmail(memberEmail);
+            return questRepository.getValidQuestsCntByMemberEmail(memberEmail);
         }else{
-            return questRepository.getTotalQuestsByMemberEmailAndDifficulty(memberEmail, difficulty);
+            return questRepository.getValidQuestsCntByMemberEmailAndDifficulty(memberEmail, difficulty);
         }
     }
 
@@ -159,9 +159,15 @@ public class QuestService {
 
     public void cancelQuest(int questId, String memberEmail) {
         int questCntByQuestId = questRepository.getQuestCntByQuestId(questId);
-        if(questCntByQuestId!=1){
+        if(questCntByQuestId != 1) {
             throw new CustomException(ErrorCode.QUEST_NOT_FOUND);
         }
+
+        int inProgressQuestCntByQuestId = questRepository.getInProgressQuestCntByQuestId(questId);
+        if(inProgressQuestCntByQuestId==0){
+            throw new CustomException(ErrorCode.QUEST_ALREADY_COMPLETED);
+        }
+
         questRepository.cancelQuest(questId);
     }
 

--- a/src/main/java/com/ssafy/questory/service/QuestService.java
+++ b/src/main/java/com/ssafy/questory/service/QuestService.java
@@ -7,9 +7,12 @@ import com.ssafy.questory.dto.response.quest.QuestResponseDto;
 import com.ssafy.questory.dto.response.quest.QuestsResponseDto;
 import com.ssafy.questory.repository.QuestRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -160,5 +163,19 @@ public class QuestService {
             throw new CustomException(ErrorCode.QUEST_NOT_FOUND);
         }
         questRepository.cancelQuest(questId);
+    }
+
+    public void startQuest(int questId, String memberEmail) {
+        int questCntByQuestId = questRepository.getQuestCntByQuestId(questId);
+        if(questCntByQuestId!=1){
+            throw new CustomException(ErrorCode.QUEST_NOT_FOUND);
+        }
+
+        int memberQuestCntByQuestId = questRepository.getMemberQuestCntByQuestId(questId, memberEmail);
+        if(memberQuestCntByQuestId!=0){
+            throw new CustomException(ErrorCode.QUEST_ALREADY_STARTED);
+        }
+
+        questRepository.startQuest(questId, memberEmail);
     }
 }

--- a/src/main/java/com/ssafy/questory/service/QuestService.java
+++ b/src/main/java/com/ssafy/questory/service/QuestService.java
@@ -2,6 +2,7 @@ package com.ssafy.questory.service;
 
 import com.ssafy.questory.common.exception.CustomException;
 import com.ssafy.questory.common.exception.ErrorCode;
+import com.ssafy.questory.dto.request.quest.QuestPositionRequestDto;
 import com.ssafy.questory.dto.request.quest.QuestRequestDto;
 import com.ssafy.questory.dto.response.quest.QuestResponseDto;
 import com.ssafy.questory.dto.response.quest.QuestsResponseDto;
@@ -184,4 +185,42 @@ public class QuestService {
 
         questRepository.startQuest(questId, memberEmail);
     }
+
+    public void completeQuest(int questId, QuestPositionRequestDto questPositionRequestDto, String memberEmail) {
+        int questCntByQuestId = questRepository.getQuestCntByQuestId(questId);
+        if(questCntByQuestId!=1){
+            throw new CustomException(ErrorCode.QUEST_NOT_FOUND);
+        }
+
+        double distance = calculateDistance(questPositionRequestDto.getAttractionLatitude(), questPositionRequestDto.getAttractionLongitude(), questPositionRequestDto.getUserLatitude(), questPositionRequestDto.getUserLongitude());
+        System.out.println("distance : "+distance);
+
+        if(distance < 1){   // 관광지와 사용자의 거리가 1km 미만이여야 퀘스트 성공
+            // 성공
+            questRepository.completeQuest(questId, memberEmail);
+        }
+        else{
+            throw new CustomException(ErrorCode.QUEST_LOCATION_TOO_FAR);
+        }
+    }
+
+    public double calculateDistance(double lat1, double lon1, double lat2, double lon2) {
+        double theta = lon1 - lon2;
+        double dist = Math.sin(deg2rad(lat1)) * Math.sin(deg2rad(lat2)) + Math.cos(deg2rad(lat1)) * Math.cos(deg2rad(lat2)) * Math.cos(deg2rad(theta));
+
+        dist = Math.acos(dist);
+        dist = rad2deg(dist);
+        dist = dist * 60 * 1.1515 * 1.609344;
+
+        return dist;
+    }
+
+    public double deg2rad(double deg) {
+        return (deg * Math.PI / 180.0);
+    }
+
+    public double rad2deg(double rad) {
+        return (rad * 180 / Math.PI);
+    }
+
 }

--- a/src/main/resources/mappers/Quest.xml
+++ b/src/main/resources/mappers/Quest.xml
@@ -14,7 +14,9 @@
             ct.content_type_name AS content_type_name,
             a.addr1 AS attraction_address,
             q.difficulty AS quest_difficulty,
-            q.quest_description AS quest_description
+            q.quest_description AS quest_description,
+            a.latitude AS attraction_latitude,
+            a.longitude AS attraction_longitude
         FROM
             quests q
         JOIN
@@ -39,7 +41,9 @@
             ct.content_type_name AS content_type_name,
             a.addr1 AS attraction_address,
             q.difficulty AS quest_difficulty,
-            q.quest_description AS quest_description
+            q.quest_description AS quest_description,
+            a.latitude AS attraction_latitude,
+            a.longitude AS attraction_longitude
         FROM
             quests q
         JOIN
@@ -71,7 +75,9 @@
         ct.content_type_name AS content_type_name,
         a.addr1 AS attraction_address,
         q.difficulty AS quest_difficulty,
-        q.quest_description AS quest_description
+        q.quest_description AS quest_description,
+        a.latitude AS attraction_latitude,
+        a.longitude AS attraction_longitude
         FROM
         quests q
         JOIN
@@ -103,7 +109,9 @@
             ct.content_type_name AS content_type_name,
             a.addr1 AS attraction_address,
             q.difficulty AS quest_difficulty,
-            q.quest_description AS quest_description
+            q.quest_description AS quest_description,
+            a.latitude AS attraction_latitude,
+            a.longitude AS attraction_longitude
         FROM quests q
         JOIN
         attractions a
@@ -130,7 +138,9 @@
             ct.content_type_name AS content_type_name,
             a.addr1 AS attraction_address,
             q.difficulty AS quest_difficulty,
-            q.quest_description AS quest_description
+            q.quest_description AS quest_description,
+            a.latitude AS attraction_latitude,
+            a.longitude AS attraction_longitude
         FROM quests q
         JOIN
             attractions a
@@ -154,35 +164,40 @@
 
     <select id="findActiveQuestsByMemberEmail" resultMap="questsMap">
         SELECT
-        q.location_quest_id AS quest_id,
-        q.title AS quest_title,
-        a.first_image1 AS attraction_image,
-        a.title AS attraction_title,
-        ct.content_type_name AS content_type_name,
-        a.addr1 AS attraction_address,
-        q.difficulty AS quest_difficulty,
-        q.quest_description AS quest_description
+            q.location_quest_id AS quest_id,
+            q.title AS quest_title,
+            a.first_image1 AS attraction_image,
+            a.title AS attraction_title,
+            ct.content_type_name AS content_type_name,
+            a.addr1 AS attraction_address,
+            q.difficulty AS quest_difficulty,
+            q.quest_description AS quest_description,
+            a.latitude AS attraction_latitude,
+            a.longitude AS attraction_longitude
         from members_quests mq
-        join quests q
-        on mq.location_quest_id = q.location_quest_id
-        JOIN attractions a
-        ON q.attraction_id = a.no
-        JOIN contenttypes ct
-        ON a.content_type_id = ct.content_type_id
-        where mq.is_completed = 'IN_PROGRESS' AND mq.member_email = #{memberEmail}
+            join quests q
+            on mq.location_quest_id = q.location_quest_id
+            JOIN attractions a
+            ON q.attraction_id = a.no
+            JOIN contenttypes ct
+            ON a.content_type_id = ct.content_type_id
+        where
+            mq.is_completed = 'IN_PROGRESS' AND mq.member_email = #{memberEmail}
         LIMIT #{offset}, #{limit};
     </select>
 
     <select id="findActiveQuestsByMemberEmailAndDifficulty" resultMap="questsMap">
         SELECT
-        q.location_quest_id AS quest_id,
-        q.title AS quest_title,
-        a.first_image1 AS attraction_image,
-        a.title AS attraction_title,
-        ct.content_type_name AS content_type_name,
-        a.addr1 AS attraction_address,
-        q.difficulty AS quest_difficulty,
-        q.quest_description AS quest_description
+            q.location_quest_id AS quest_id,
+            q.title AS quest_title,
+            a.first_image1 AS attraction_image,
+            a.title AS attraction_title,
+            ct.content_type_name AS content_type_name,
+            a.addr1 AS attraction_address,
+            q.difficulty AS quest_difficulty,
+            q.quest_description AS quest_description,
+            a.latitude AS attraction_latitude,
+            a.longitude AS attraction_longitude
         from members_quests mq
         join quests q
         on mq.location_quest_id = q.location_quest_id
@@ -344,6 +359,8 @@
         <result column="attraction_address" property="attractionAddress" />
         <result column="quest_difficulty" property="questDifficulty" />
         <result column="quest_description" property="questDescription" />
+        <result column="attraction_latitude" property="attractionLatitude" />
+        <result column="attraction_longitude" property="attractionLongitude" />
     </resultMap>
 
     <resultMap type="QuestResponseDto" id="questMap">

--- a/src/main/resources/mappers/Quest.xml
+++ b/src/main/resources/mappers/Quest.xml
@@ -32,6 +32,38 @@
 
     <select id="findValidQuestsByMemberEmail" resultMap="questsMap" resultType="com.ssafy.questory.dto.response.quest.QuestsResponseDto">
         SELECT
+            q.location_quest_id AS quest_id,
+            q.title AS quest_title,
+            a.first_image1 AS attraction_image,
+            a.title AS attraction_title,
+            ct.content_type_name AS content_type_name,
+            a.addr1 AS attraction_address,
+            q.difficulty AS quest_difficulty,
+            q.quest_description AS quest_description
+        FROM
+            quests q
+        JOIN
+            attractions a ON q.content_type_id = a.content_type_id AND q.attraction_id = a.no
+        JOIN
+            contenttypes ct ON a.content_type_id = ct.content_type_id
+        WHERE
+            q.location_quest_id NOT IN (select location_quest_id from members_quests where member_email = #{memberEmail})
+            AND  q.is_deleted = 0 AND q.is_private = 0
+        LIMIT #{offset}, #{limit};
+    </select>
+
+    <select id="getValidQuestsCntByMemberEmail">
+        SELECT
+            COUNT(*)
+        FROM
+            quests q
+        WHERE
+            q.location_quest_id NOT IN (select location_quest_id from members_quests where member_email = #{memberEmail})
+            AND  q.is_deleted = 0 AND q.is_private = 0;
+    </select>
+
+    <select id="findValidQuestsByMemberEmailAndDifficulty" resultMap="questsMap" resultType="com.ssafy.questory.dto.response.quest.QuestsResponseDto">
+        SELECT
         q.location_quest_id AS quest_id,
         q.title AS quest_title,
         a.first_image1 AS attraction_image,
@@ -42,64 +74,24 @@
         q.quest_description AS quest_description
         FROM
         quests q
-        LEFT JOIN
-        (select * from members_quests where member_email = #{memberEmail}) mq
-        ON q.location_quest_id = mq.location_quest_id
         JOIN
         attractions a ON q.content_type_id = a.content_type_id AND q.attraction_id = a.no
         JOIN
         contenttypes ct ON a.content_type_id = ct.content_type_id
         WHERE
-        (mq.is_completed = 'READY' OR mq.is_completed IS NULL) AND  q.is_deleted = 0 AND q.is_private = 0
+        q.location_quest_id NOT IN (select location_quest_id from members_quests where member_email = #{memberEmail})
+        AND  q.is_deleted = 0 AND q.is_private = 0 AND q.difficulty=#{difficulty}
         LIMIT #{offset}, #{limit};
     </select>
 
-    <select id="getTotalQuestsByMemberEmail">
+    <select id="getValidQuestsCntByMemberEmailAndDifficulty">
         SELECT
-            COUNT(*)
-        FROM
-            quests q
-        LEFT JOIN
-            (select * from members_quests where member_email = #{memberEmail}) mq
-            ON q.location_quest_id = mq.location_quest_id
-        WHERE
-            (mq.is_completed = 'READY' OR mq.is_completed IS NULL) AND  q.is_deleted = 0 AND q.is_private = 0;
-    </select>
-
-    <select id="findQuestsByMemberEmailAndDifficulty" resultMap="questsMap" resultType="com.ssafy.questory.dto.response.quest.QuestsResponseDto">
-        SELECT
-        q.location_quest_id AS quest_id,
-        q.title AS quest_title,
-        a.first_image1 AS attraction_image,
-        a.title AS attraction_title,
-        ct.content_type_name AS content_type_name,
-        a.addr1 AS attraction_address,
-        q.difficulty AS quest_difficulty,
-        q.quest_description AS quest_description
+        COUNT(*)
         FROM
         quests q
-        LEFT JOIN
-        (select * from members_quests where member_email = #{memberEmail}) mq
-        ON q.location_quest_id = mq.location_quest_id
-        JOIN
-        attractions a ON q.content_type_id = a.content_type_id AND q.attraction_id = a.no
-        JOIN
-        contenttypes ct ON a.content_type_id = ct.content_type_id
         WHERE
-        (mq.is_completed = 'READY' OR mq.is_completed IS NULL) AND  q.is_deleted = 0 AND q.is_private = 0 AND q.difficulty=#{difficulty}
-        LIMIT #{offset}, #{limit};
-    </select>
-
-    <select id="getTotalQuestsByMemberEmailAndDifficulty">
-        SELECT
-            COUNT(*)
-        FROM
-            quests q
-        LEFT JOIN
-            (select * from members_quests where member_email = #{memberEmail}) mq
-            ON q.location_quest_id = mq.location_quest_id
-        WHERE
-            (mq.is_completed = 'READY' OR mq.is_completed IS NULL) AND  q.is_deleted = 0 AND q.is_private = 0 AND difficulty=#{difficulty};
+        q.location_quest_id NOT IN (select location_quest_id from members_quests where member_email = #{memberEmail}))
+        AND  q.is_deleted = 0 AND q.is_private = 0 AND difficulty=#{difficulty};
     </select>
 
     <select id="findQuestsCreatedByMe" resultMap="questsMap">
@@ -321,12 +313,15 @@
     </select>
 
     <select id="cancelQuest">
-        UPDATE
+        DELETE FROM
             Members_Quests
-        SET
-            is_completed = 'READY'
-        WHERE
-            location_quest_id = #{questId};
+        WHERE location_quest_id = #{questId};
+    </select>
+
+    <select id="getInProgressQuestCntByQuestId">
+        SELECT COUNT(*)
+        FROM members_quests
+        WHERE location_quest_id = #{questId} AND is_completed = 'IN_PROGRESS';
     </select>
 
     <select id="startQuest">

--- a/src/main/resources/mappers/Quest.xml
+++ b/src/main/resources/mappers/Quest.xml
@@ -350,6 +350,12 @@
         WHERE member_email = #{memberEmail} AND location_quest_id = #{questId};
     </select>
 
+    <select id="completeQuest">
+        UPDATE members_Quests
+        SET is_completed='COMPLETED'
+        WHERE member_email=#{memberEmail} AND location_quest_id= #{questId};
+    </select>
+
     <resultMap type="QuestsResponseDto" id="questsMap">
         <result column="location_quest_id" property="questId" />
         <result column="quest_title" property="questTitle" />

--- a/src/main/resources/mappers/Quest.xml
+++ b/src/main/resources/mappers/Quest.xml
@@ -329,6 +329,17 @@
             location_quest_id = #{questId};
     </select>
 
+    <select id="startQuest">
+        INSERT INTO Members_Quests(member_email, location_quest_id)
+        VALUES (#{memberEmail}, #{questId});
+    </select>
+
+    <select id="getMemberQuestCntByQuestId">
+        SELECT COUNT(*)
+        FROM members_quests
+        WHERE member_email = #{memberEmail} AND location_quest_id = #{questId};
+    </select>
+
     <resultMap type="QuestsResponseDto" id="questsMap">
         <result column="location_quest_id" property="questId" />
         <result column="quest_title" property="questTitle" />

--- a/src/main/resources/sql/questory.sql
+++ b/src/main/resources/sql/questory.sql
@@ -98,6 +98,6 @@ CREATE TABLE Quests (
 CREATE TABLE Members_Quests (
     member_email VARCHAR(40) NOT NULL,
     location_quest_id INT NOT NULL,
-    is_completed ENUM('READY', 'IN_PROGRESS', 'COMPLETED') DEFAULT 'READY',
+    is_completed ENUM('IN_PROGRESS', 'COMPLETED') DEFAULT 'IN_PROGRESS',
     created_at DATETIME DEFAULT NOW()
 );


### PR DESCRIPTION
# 관련 이슈
- resolves: #56 


# 작업 내용
- 퀘스트 시작 기능 구현
- 퀘스트 완료 기능 구현
    - QuestsResponseDto 수정 : 위도, 경도 데이터 추가
    - 완료한 퀘스트의 스탬프 추가 기능 구현
- members-quests 테이블의 is_completed 상태값 수정
    - IN_PROGRESS, COMPLETED