### PR TITLE
[FIX] #75 - response dto 수정

### DIFF
--- a/src/main/java/com/ssafy/questory/dto/response/quest/QuestRecommendationResponseDto.java
+++ b/src/main/java/com/ssafy/questory/dto/response/quest/QuestRecommendationResponseDto.java
@@ -11,17 +11,19 @@ public class QuestRecommendationResponseDto {
     private Long questId;
     private String title;
     private String description;
-    private DifficultyStatus difficulty;
+    private String difficulty;
+    private int exp;
     private int participantCount;
     private LocalDateTime createdAt;
 
     @Builder
     private QuestRecommendationResponseDto(Long questId, String title, String description,
-                                           DifficultyStatus difficulty, int participantCount, LocalDateTime createdAt) {
+                                           String difficulty, int exp, int participantCount, LocalDateTime createdAt) {
         this.questId = questId;
         this.title = title;
         this.description = description;
         this.difficulty = difficulty;
+        this.exp = exp;
         this.participantCount = participantCount;
         this.createdAt = createdAt;
     }

--- a/src/main/resources/mappers/Quest.xml
+++ b/src/main/resources/mappers/Quest.xml
@@ -393,6 +393,12 @@
         q.title,
         q.quest_description AS description,
         q.difficulty,
+        CASE q.difficulty
+        WHEN 'EASY' THEN 30
+        WHEN 'MEDIUM' THEN 50
+        WHEN 'HARD' THEN 100
+        ELSE 0
+        END AS exp,
         COUNT(mq.member_email) AS participantCount,
         q.created_at
         FROM Quests q


### PR DESCRIPTION
## 관련 이슈
- resolves: #75 

## 작업 내용
`QuestRecommendationResponseDto`에 경험치 제공량 정보 포함하도록 수정