### PR TITLE
[FEAT] #78 - 메인페이지 여행 루트 리스트 조회 기능 구현

### DIFF
--- a/src/main/java/com/ssafy/questory/controller/PlanController.java
+++ b/src/main/java/com/ssafy/questory/controller/PlanController.java
@@ -89,6 +89,14 @@ public class PlanController {
         return ResponseEntity.status(HttpStatus.OK).body(plansListResponseDtoList);
     }
 
+    @GetMapping("/mainPage")
+    @Operation(summary = "모든 여행 계획 목록 조회", description = "모든 여행 계획 목록을 조회합니다.")
+    public ResponseEntity<List<PlansListResponseDto>> findPlansListForMainPage() {
+        List<PlansListResponseDto> plansListResponseDtoList = planService.findPlansListForMainPage();
+
+        return ResponseEntity.status(HttpStatus.OK).body(plansListResponseDtoList);
+    }
+
     @GetMapping("/shared")
     @Operation(summary = "공유 받은 여행 계획 목록 조회", description = "공유 받은 여행 계획 목록을 조회합니다.")
     public ResponseEntity<List<PlansListResponseDto>> findSharedPlansListCreatedByMe(@RequestHeader(value = "Authorization", required = false) String authorizationHeader) {

--- a/src/main/java/com/ssafy/questory/dto/response/plan/PlanResponseDto.java
+++ b/src/main/java/com/ssafy/questory/dto/response/plan/PlanResponseDto.java
@@ -1,0 +1,24 @@
+package com.ssafy.questory.dto.response.plan;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+@ToString
+//@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class PlanResponseDto {
+    private String title;
+    private int totalDays;
+    private String destination;
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
+    private String description;
+}

--- a/src/main/java/com/ssafy/questory/repository/PlanRepository.java
+++ b/src/main/java/com/ssafy/questory/repository/PlanRepository.java
@@ -18,5 +18,6 @@ public interface PlanRepository {
     int deleteById(Long planId);
     List<PlansListResponseDto> findPlansListCreatedByMe(@Param("memberEmail") String memberEmail);
     List<PlansListResponseDto> findPlansListCreatedByNotMe(@Param("memberEmail") String memberEmail);
+    List<PlansListResponseDto> findPlansListForMainPage();
     List<PlansListResponseDto> selectSharedPlansByMemberEmail(@Param("memberEmail") String memberEmail);
 }

--- a/src/main/java/com/ssafy/questory/service/PlanService.java
+++ b/src/main/java/com/ssafy/questory/service/PlanService.java
@@ -161,4 +161,8 @@ public class PlanService {
     public List<PlansListResponseDto> selectSharedPlansByMemberEmail(String memberEmail) {
         return planRepository.selectSharedPlansByMemberEmail(memberEmail);
     }
+
+    public List<PlansListResponseDto> findPlansListForMainPage() {
+        return planRepository.findPlansListForMainPage();
+    }
 }

--- a/src/main/resources/mappers/plan.xml
+++ b/src/main/resources/mappers/plan.xml
@@ -84,6 +84,39 @@
             ]]>
     </select>
 
+    <select id="findPlansListForMainPage">
+        <![CDATA[
+                SELECT
+                p.plan_id AS plan_id,
+                p.title AS plan_title,
+                p.description AS plan_description,
+                p.start_date AS startDate,
+                p.end_date AS endDate,
+                DATEDIFF(p.end_date, p.start_date) + 1 AS duration,
+                CASE
+                WHEN NOW() < p.start_date THEN 'PLANNING'
+                WHEN NOW() BETWEEN p.start_date AND p.end_date THEN 'CONFIRMED'
+                WHEN NOW() > p.end_date THEN 'COMPLETED'
+                ELSE 'UNKNOWN'
+                END AS status,
+                COUNT(DISTINCT pr.attraction_id) AS routes_cnt,
+                CASE
+                WHEN NOW() < p.start_date THEN 0
+                WHEN NOW() > p.end_date THEN 100
+                ELSE ROUND(
+                (DATEDIFF(NOW(), p.start_date) + 1) / (DATEDIFF(p.end_date, p.start_date) + 1) * 100,
+                0
+                )
+                END AS completion_rate,
+                p.created_at AS createdAt
+                FROM Plans p
+                LEFT JOIN Plans_Routes pr ON p.plan_id = pr.plan_id
+                GROUP BY
+                p.plan_id, p.title, p.description, p.start_date, p.end_date, p.created_at
+                LIMIT 6;
+            ]]>
+    </select>
+
     <select id="selectSharedPlansByMemberEmail" resultMap="plansMap" resultType="com.ssafy.questory.dto.response.plan.PlansListResponseDto">
         <![CDATA[
             SELECT


### PR DESCRIPTION
# 관련 이슈
- resolves: #78 


# 작업 내용
- 메인페이지 여행 루트 리스트 조회 기능 구현
    - 여행 루트 6개만 조회